### PR TITLE
Add Layering, tests, and example

### DIFF
--- a/docs/examples/graphics/arc/index.html
+++ b/docs/examples/graphics/arc/index.html
@@ -5,16 +5,12 @@
 </head>
 <body>
   <canvas id="game" width="480" height="400"></canvas>
-  <script src="../../../dist/chs.iife.js"></script>
+  <script src="../../../../dist/chs.iife.js"></script>
   <script id="code">
     var a = new Arc(30, 0, 90, 0);
     a.setColor(Color.RED);
-    a.setPosition(getWidth() / 2, getHeight() / 2);
+    a.setPosition(50, 50);
     add(a);
-    setTimer(() => {
-      a.startAngle += Math.PI / 16;
-      a.endAngle += Math.PI / 16;
-    }, 1);
   </script>
 </body>
 </html>

--- a/docs/examples/graphics/circle/index.html
+++ b/docs/examples/graphics/circle/index.html
@@ -5,7 +5,7 @@
 </head>
 <body>
   <canvas id="game" width="480" height="400"></canvas>
-  <script src="../../../dist/chs.iife.js"></script>
+  <script src="../../../../dist/chs.iife.js"></script>
   <script id="code">
     let radius = 20;
     let growing = true;

--- a/docs/examples/graphics/layering.html
+++ b/docs/examples/graphics/layering.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Layering Test</title>
+</head>
+<body>
+  <canvas id="game" width="480" height="400"></canvas>
+  <script src="../../../../dist/chs.iife.js"></script>
+  <script id="code">
+      let rectangles = [];
+      let colors = [
+          '#F72585',
+          '#B5179E',
+          '#7209B7',
+          '#560bad',
+          '#480ca8',
+          '#3a0ca3',
+          '#3f37c9',
+          '#4361ee',
+          '#4895ef',
+          '#4cc9f0',
+      ]
+      for (let i = 0; i < 10; i++) {
+          const rect = new Rectangle(getWidth() / 5, 100);
+          rect.setColor(colors[i]);
+          rect.setPosition(i * getWidth() / 10 - 50, i * 10);
+          add(rect);
+          rectangles.push(rect);
+      }
+
+      let reverse = true;
+      setInterval(() => {
+        rectangles.forEach((rectangle, i) => {
+            rectangle.layer = reverse ? 10 - i : i;
+        })
+        reverse = !reverse;
+      }, 1000);
+  </script>
+</body>
+</html>

--- a/docs/examples/graphics/line/index.html
+++ b/docs/examples/graphics/line/index.html
@@ -5,7 +5,7 @@
 </head>
 <body>
   <canvas id="game" width="480" height="400"></canvas>
-  <script src="../../../dist/chs.iife.js"></script>
+  <script src="../../../../dist/chs.iife.js"></script>
   <script id="code">
     var line = new Line(20, 20, 120, 120);
     add(line);

--- a/docs/examples/graphics/oval/index.html
+++ b/docs/examples/graphics/oval/index.html
@@ -5,7 +5,7 @@
 </head>
 <body>
   <canvas id="game" width="480" height="400"></canvas>
-  <script src="../../../dist/chs.iife.js"></script>
+  <script src="../../../../dist/chs.iife.js"></script>
   <script id="code">
     let width = 40;
     let height = 40;

--- a/docs/examples/graphics/polygon/index.html
+++ b/docs/examples/graphics/polygon/index.html
@@ -7,7 +7,7 @@
 
 <body>
     <canvas id="game" width="480" height="400"></canvas>
-    <script src="../../../dist/chs.iife.js"></script>
+    <script src="../../../../dist/chs.iife.js"></script>
     <script id="code">
         const shapes = [];
         const position = { x: 0, y: 0 };

--- a/docs/examples/graphics/rectangle/index.html
+++ b/docs/examples/graphics/rectangle/index.html
@@ -5,7 +5,7 @@
 </head>
 <body>
   <canvas id="game" width="480" height="400"></canvas>
-  <script src="../../../dist/chs.iife.js"></script>
+  <script src="../../../../dist/chs.iife.js"></script>
   <script id="code">
     let width = 40;
     let height = 40;

--- a/docs/examples/graphics/sound/index.html
+++ b/docs/examples/graphics/sound/index.html
@@ -5,7 +5,7 @@
 </head>
 <body>
   <canvas id="game" width="480" height="400"></canvas>
-  <script src="../../../dist/chs.iife.js"></script>
+  <script src="../../../../dist/chs.iife.js"></script>
   <script id="code">
     var s = new Sound();
     s.play();

--- a/docs/examples/graphics/text/index.html
+++ b/docs/examples/graphics/text/index.html
@@ -5,10 +5,9 @@
 </head>
 <body>
   <canvas id="game" width="480" height="400"></canvas>
-  <script src="../../../dist/chs.iife.js"></script>
+  <script src="../../../../dist/chs.iife.js"></script>
   <script id="code">
     var t = new Text("Hello World");
-    t.setPosition(getWidth() / 2, getHeight() / 2);
     add(t);
     mouseMoveMethod(({x, y}) => {
         t.setPosition(x, y);

--- a/src/graphics.js
+++ b/src/graphics.js
@@ -541,6 +541,10 @@ class CodeHSGraphics {
         for (let i = this.elementPoolSize; i--; ) {
             elem = this.elementPool[i];
 
+            if (elem.__sortInvalidated) {
+                sortPool = true;
+                elem.__sortInvalidated = false;
+            }
             if (!elem.alive) {
                 sortPool = true;
                 this.elementPoolSize--;
@@ -549,8 +553,10 @@ class CodeHSGraphics {
             }
         }
         // sort all dead elements to the end of the pool
+        // and all elements with lower layer before elements
+        // with higher layer
         if (sortPool) {
-            this.elementPool.sort((a, b) => b.alive - a.alive);
+            this.elementPool.sort((a, b) => b.alive - a.alive || a.layer - b.layer);
         }
     }
 

--- a/src/thing.js
+++ b/src/thing.js
@@ -19,6 +19,20 @@ export default class Thing {
         this.filled = true;
         this.hasBorder = false;
         this.rotation = 0;
+        this.__layer = 1;
+    }
+
+    /**
+     * Sets the layer of the Thing and marks the sortInvalidated flag
+     * so any Graphics instances drawing it know to re-sort.
+     */
+    set layer(newLayer) {
+        this.__sortInvalidated = true;
+        this.__layer = newLayer;
+    }
+
+    get layer() {
+        return this.__layer;
     }
 
     /**

--- a/src/webimage.js
+++ b/src/webimage.js
@@ -440,5 +440,3 @@ export default class WebImage extends Thing {
         this.setPixel(x, y, ALPHA, val);
     }
 }
-
-module.exports = WebImage;

--- a/test/thing.test.js
+++ b/test/thing.test.js
@@ -1,9 +1,18 @@
+import Graphics from '../src/graphics.js';
 import Thing from '../src/thing.js';
 
 describe('Thing', () => {
-    describe('Doing the thing', () => {
-        it('Does the thing', () => {
-            expect(true).toBe(true);
+    describe('Layering', () => {
+        it('Changing layer forces a re-sort', () => {
+            const g = new Graphics();
+            const t1 = new Thing();
+            const t2 = new Thing();
+            g.add(t2);
+            g.add(t1);
+            t2.layer = 2;
+            expect(g.elementPool.indexOf(t2)).toBe(0);
+            g.redraw();
+            expect(g.elementPool.indexOf(t2)).toBe(1);
         });
     });
 });


### PR DESCRIPTION
Adds Layering to the JS Lib with the `layer` property on `Thing`s.
When a `Thing` has its `layer` set, it's marked as `__sortInvalidated`, and the next `redraw` will identify that a sort needs to happen. Elements will be sorted so dead elements appear last, and elements with a lower layer appear before elements with a higher layer.

fixes #7

![layering](https://user-images.githubusercontent.com/6645121/137375520-01ba4bbd-f139-46c8-84ac-31ecc20ce3bf.gif)


