### PR TITLE
Fix removal not to sort .alive elements to the end

### DIFF
--- a/docs/examples/graphics/removal.html
+++ b/docs/examples/graphics/removal.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Removal Test</title>
+    </head>
+    <body>
+        <canvas id="game" width="480" height="400"></canvas>
+        <script src="../../../../dist/chs.iife.js"></script>
+        <script id="code">
+            const POP_URL = 'https://codehs.com/uploads/2b40bf21f8a1b10f6e11ef774e3812c9';
+
+            const pop = new Audio(POP_URL);
+            setBackgroundColor(Color.BLACK);
+            const CIRCLE_DIAMETER = 30;
+            for (let row = 0; row < (getHeight() - CIRCLE_DIAMETER) / CIRCLE_DIAMETER; row++) {
+                for (let col = 0; col < getWidth() / CIRCLE_DIAMETER; col++) {
+                    const bubble = new Group();
+                    const circle = new Circle(CIRCLE_DIAMETER / 2);
+                    circle.setColor(Color.WHITE);
+                    circle.setOpacity(0.5);
+                    bubble.add(circle);
+
+                    const highlight = new Circle(CIRCLE_DIAMETER / 5);
+                    highlight.setColor(Color.WHITE);
+                    highlight.setPosition(CIRCLE_DIAMETER / 4, -CIRCLE_DIAMETER / 4);
+                    highlight.setOpacity(0.5);
+                    bubble.add(highlight);
+
+                    bubble.setPosition(col * CIRCLE_DIAMETER, row * CIRCLE_DIAMETER);
+                    add(bubble);
+                }
+            }
+
+            mouseDragMethod(e => {
+                const el = getElementAt(e.getX(), e.getY());
+                if (el) {
+                    if (document.querySelector('#sound').checked) {
+                        if (pop.paused) {
+                            pop.play();
+                        } else {
+                            pop.currentTime = 0;
+                        }
+                    }
+                    remove(el);
+                }
+            });
+        </script>
+        <input type="checkbox" id="sound" />Play sound
+        <p>An example of removing elements.</p>
+    </body>
+</html>

--- a/src/graphics/index.js
+++ b/src/graphics/index.js
@@ -485,7 +485,7 @@ class GraphicsManager extends Manager {
         // with higher layer
         if (sortPool) {
             this.elementPoolSize -= numberRemovedElementsFound;
-            this.elementPool.sort((a, b) => a.alive - b.alive || a.layer - b.layer);
+            this.elementPool.sort((a, b) => b.alive - a.alive || a.layer - b.layer);
         }
     }
 

--- a/test/graphics.test.js
+++ b/test/graphics.test.js
@@ -264,6 +264,28 @@ describe('Graphics', () => {
             g.redraw();
             expect(arcSpy).not.toHaveBeenCalled();
         });
+        it('remove() preserves other living elements', () => {
+            const g = new Graphics({ shouldUpdate: false });
+            const c1 = new Circle(10);
+            const c2 = new Circle(10);
+            const c3 = new Circle(10);
+            g.add(c1);
+            g.add(c2);
+            g.add(c3);
+            g.redraw();
+            g.remove(c1);
+            expect(g.elementPoolSize).toEqual(3);
+            expect(g.elementPool[0].alive).toBeFalse();
+            expect(g.elementPool[1].alive).toBeTrue();
+            expect(g.elementPool[2].alive).toBeTrue();
+            g.redraw();
+            expect(g.elementPoolSize).toEqual(2);
+            g.redraw();
+            expect(g.elementPoolSize).toEqual(2);
+            expect(g.elementPool[0].alive).toBeTrue();
+            expect(g.elementPool[1].alive).toBeTrue();
+            expect(g.elementPool[2].alive).toBeFalse();
+        });
     });
     describe('setBackgroundColor', () => {
         it('Causes drawBackground to be invoked in redraw()', () => {


### PR DESCRIPTION
Previously `.alive` elements were sorted to the end, which would cascade and cause all elements to be removed.
Added a test that captured that behavior, fixed it, and added an example to confirm.