### PR TITLE
Don't shrink the hiddenCanvas used for drawing WebImages when resizing

### DIFF
--- a/docs/examples/graphics/webimage/filtering.html
+++ b/docs/examples/graphics/webimage/filtering.html
@@ -86,8 +86,8 @@
             const t = new Text(
                 'Caution:\nThis example has flashing lights. Click to continue',
                 '12pt Arial',
-                { veritcal: 'center', horizontal: 'center' }
             );
+            t.setAnchor({vertical: 0.5, horizontal: 0.5});
             t.setPosition(getWidth() / 2, getHeight() / 2);
             add(t);
 

--- a/docs/examples/graphics/webimage/scaling.html
+++ b/docs/examples/graphics/webimage/scaling.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Scaling</title>
+    </head>
+</html>
+<body>
+    <canvas id="game" width="480" height="400"></canvas>
+    <script src="../../../../dist/chs.iife.js"></script>
+    <script id="code">
+        const IMG_URL =
+            'https://upload.wikimedia.org/wikipedia/commons/d/da/The_Parthenon_in_Athens.jpg';
+
+        const image = new WebImage(IMG_URL);
+
+        let w = 10;
+        let h = 10;
+        let aspectRatio = 1;
+        let maxW;
+        let dh = -4;
+        image.loaded(() => {
+            add(image);
+            aspectRatio = image.width / image.height;
+            maxW = image.width;
+            w = image.width;
+            h = image.height;
+            start();
+        });
+        start = () => {
+            setTimer(() => {
+                h += dh;
+                w = aspectRatio * h;
+                image.setSize(w, h);
+                if (h <= 50 || w > maxW) {
+                    dh = -dh;
+                }
+            }, 30);
+        };
+    </script>
+    <p>This program resizes the image.</p>
+</body>

--- a/src/graphics/webimage.js
+++ b/src/graphics/webimage.js
@@ -70,6 +70,8 @@ class WebImage extends Thing {
         }
 
         this._hiddenCanvas = document.createElement('canvas');
+        this._hiddenCanvas.width = 1;
+        this._hiddenCanvas.height = 1;
 
         this.image = new Image();
         this.image.crossOrigin = true;
@@ -359,8 +361,8 @@ class WebImage extends Thing {
      * This is automatically called after operations that modify ImageData.
      */
     updateHiddenCanvas() {
-        this._hiddenCanvas.width = this.width;
-        this._hiddenCanvas.height = this.height;
+        this._hiddenCanvas.width = Math.max(this._hiddenCanvas.width, this.width);
+        this._hiddenCanvas.height = Math.max(this._hiddenCanvas.height, this.height);
         const context = this._hiddenCanvas.getContext('2d');
         context.putImageData(this.data, 0, 0);
         this._hiddenCanvasOutOfSync = false;


### PR DESCRIPTION
Fixes a bug that results in cropping the image.

Previous behavior
![crop](https://user-images.githubusercontent.com/6645121/144932190-660c802b-3c5d-4012-9d10-685dfeb4b3fa.gif)

Fixed behavior
![crop](https://user-images.githubusercontent.com/6645121/144932248-acc4514f-a096-4db4-856c-6abdc29f230e.gif)

