### PR TITLE
Improve resolution on devices with >1 pixel density

### DIFF
--- a/src/graphics/index.js
+++ b/src/graphics/index.js
@@ -605,9 +605,14 @@ class GraphicsManager extends Manager {
         const context = this.getContext();
         x *= this.devicePixelRatio;
         y *= this.devicePixelRatio;
-        const data = context.getImageData(x, y, 1, 1).data;
+        const pixelData = context.getImageData(x, y, 1, 1).data;
         const index = 0;
-        return [data[index + 0], data[index + 1], data[index + 2], data[index + 3]];
+        return [
+            pixelData[index + 0],
+            pixelData[index + 1],
+            pixelData[index + 2],
+            pixelData[index + 3],
+        ];
     }
 
     /**

--- a/src/graphics/index.js
+++ b/src/graphics/index.js
@@ -597,6 +597,9 @@ class GraphicsManager extends Manager {
 
     /**
      * Return the RGBA value of the pixel at the x, y coordinate.
+     * @param {number} x - X coordinate
+     * @param {number} y - Y coordinate
+     * @returns {Array<number>} pixel - the [r, g, b, a] values for the pixel.
      */
     getPixel(x, y) {
         const context = this.getContext();

--- a/test/arc.test.js
+++ b/test/arc.test.js
@@ -124,9 +124,8 @@ describe('arc', () => {
             a.setColor('red');
             g.add(a);
             g.redraw();
-            const context = g.getContext();
-            const pixel = context.getImageData(0, 0, 1, 1);
-            expect(pixel.data).toEqual(new Uint8ClampedArray([255, 0, 0, 255]));
+            const pixel = g.getPixel(0, 0);
+            expect(pixel).toEqual([255, 0, 0, 255]);
         });
     });
 
@@ -265,15 +264,13 @@ describe('arc', () => {
             a.setColor('red');
             g.add(a);
             g.redraw();
-            let topLeftPixel = g.getContext().getImageData(0, 0, 1, 1);
-            expect(topLeftPixel.data).toEqual(new Uint8ClampedArray([0, 0, 0, 0]));
+            let topLeftPixel = g.getPixel(0, 0);
+            expect(topLeftPixel).toEqual([0, 0, 0, 0]);
             a.setPosition(g.getWidth() - a.radius / 2, g.getHeight() - a.radius / 2);
 
             g.redraw();
-            const bottomRightPixel = g
-                .getContext()
-                .getImageData(g.getWidth() - 1, g.getHeight() - 1, 1, 1);
-            expect(bottomRightPixel.data).toEqual(new Uint8ClampedArray([255, 0, 0, 255]));
+            const bottomRightPixel = g.getPixel(g.getWidth() - 1, g.getHeight() - 1);
+            expect(bottomRightPixel).toEqual([255, 0, 0, 255]);
         });
         it('{vertical: 0.5, horizontal: 0.5}', () => {
             const a = new Arc(10, 0, 359, Arc.DEGREES);
@@ -283,15 +280,13 @@ describe('arc', () => {
             a.setColor('red');
             g.add(a);
             g.redraw();
-            let topLeftPixel = g.getContext().getImageData(0, 0, 1, 1);
-            expect(topLeftPixel.data).toEqual(new Uint8ClampedArray([255, 0, 0, 255]));
+            let topLeftPixel = g.getPixel(0, 0);
+            expect(topLeftPixel).toEqual([255, 0, 0, 255]);
             a.setPosition(g.getWidth(), g.getHeight());
 
             g.redraw();
-            const bottomRightPixel = g
-                .getContext()
-                .getImageData(g.getWidth() - 1, g.getHeight() - 1, 1, 1);
-            expect(bottomRightPixel.data).toEqual(new Uint8ClampedArray([255, 0, 0, 255]));
+            const bottomRightPixel = g.getPixel(g.getWidth() - 1, g.getHeight() - 1);
+            expect(bottomRightPixel).toEqual([255, 0, 0, 255]);
         });
     });
 
@@ -303,12 +298,12 @@ describe('arc', () => {
             g.shouldUpdate = false;
             g.add(a);
             g.redraw();
-            let topLeftPixel = g.getContext().getImageData(0, 0, 1, 1);
-            expect(topLeftPixel.data).toEqual(new Uint8ClampedArray([0, 0, 0, 0]));
+            let topLeftPixel = g.getPixel(0, 0);
+            expect(topLeftPixel).toEqual([0, 0, 0, 0]);
             a.setAnchor({ vertical: 0.5, horizontal: 0.4 });
             g.redraw();
-            topLeftPixel = g.getContext().getImageData(1, 1, 1, 1);
-            expect(topLeftPixel.data).toEqual(new Uint8ClampedArray([255, 0, 0, 255]));
+            topLeftPixel = g.getPixel(1, 1);
+            expect(topLeftPixel).toEqual([255, 0, 0, 255]);
         });
     });
 

--- a/test/circle.test.js
+++ b/test/circle.test.js
@@ -94,12 +94,11 @@ describe('Circle', () => {
             g.shouldUpdate = false;
             const circle = new Circle(2);
             circle.setColor(Color.RED);
-            const context = g.getContext();
             circle.setPosition(20, 20);
             g.add(circle);
             g.redraw();
-            const pixel = context.getImageData(20, 20, 1, 1);
-            expect(pixel.data).toEqual(new Uint8ClampedArray([255, 0, 0, 255]));
+            const pixel = g.getPixel(20, 20);
+            expect(pixel).toEqual([255, 0, 0, 255]);
         });
     });
     it('getRadius returns radius', () => {
@@ -181,30 +180,26 @@ describe('Circle', () => {
             // a circle at the top left should be placed exactly
             // at the origin, with the bottom right quadrant visible
             g.redraw();
-            let topLeftPixel = g.getContext().getImageData(0, 0, 1, 1);
-            expect(topLeftPixel.data).toEqual(new Uint8ClampedArray([255, 0, 0, 255]));
+            let topLeftPixel = g.getPixel(0, 0);
+            expect(topLeftPixel).toEqual([255, 0, 0, 255]);
 
             // a circle at the top left with anchor 0, 0 should be drawn
             // down and to the right of the origin, with its entire
             // self visible
             c.setAnchor({ vertical: 0, horizontal: 0 });
             g.redraw();
-            topLeftPixel = g.getContext().getImageData(0, 0, 1, 1);
-            expect(topLeftPixel.data).toEqual(new Uint8ClampedArray([0, 0, 0, 0]));
+            topLeftPixel = g.getPixel(0, 0, 1, 1);
+            expect(topLeftPixel).toEqual([0, 0, 0, 0]);
 
             c.setPosition(g.getWidth(), g.getHeight());
             c.setAnchor({ vertical: 1, horizontal: 1 });
             g.redraw();
-            let bottomRightPixel = g
-                .getContext()
-                .getImageData(g.getWidth() - 1, g.getHeight() - 1, 1, 1);
-            expect(bottomRightPixel.data).toEqual(new Uint8ClampedArray([0, 0, 0, 0]));
+            let bottomRightPixel = g.getPixel(g.getWidth() - 1, g.getHeight() - 1);
+            expect(bottomRightPixel).toEqual([0, 0, 0, 0]);
             c.setAnchor({ vertical: 0.5, horizontal: 0.5 });
             g.redraw();
-            bottomRightPixel = g
-                .getContext()
-                .getImageData(g.getWidth() - 1, g.getHeight() - 1, 1, 1);
-            expect(bottomRightPixel.data).toEqual(new Uint8ClampedArray([255, 0, 0, 255]));
+            bottomRightPixel = g.getPixel(g.getWidth() - 1, g.getHeight() - 1);
+            expect(bottomRightPixel).toEqual([255, 0, 0, 255]);
         });
     });
 

--- a/test/graphics.test.js
+++ b/test/graphics.test.js
@@ -39,12 +39,13 @@ describe('Graphics', () => {
         });
     });
     describe('setSize', () => {
-        it('Changes the size of the backed canvas', () => {
+        it('Changes the size of the backed canvas, considering the devicePixelRatio of the device', () => {
+            window.devicePixelRatio = 2;
             const g = new Graphics({ shouldUpdate: false });
             g.setSize(20, 20);
             const canvas = document.querySelector('canvas');
-            expect(canvas.width).toEqual(20);
-            expect(canvas.height).toEqual(20);
+            expect(canvas.width).toEqual(20 * window.devicePixelRatio);
+            expect(canvas.height).toEqual(20 * window.devicePixelRatio);
         });
     });
     describe('setFullscreen', () => {
@@ -53,8 +54,7 @@ describe('Graphics', () => {
             g.setFullscreen();
             const canvas = g.getCanvas();
             expect(canvas.width).toEqual(document.body.offsetWidth - FULLSCREEN_PADDING);
-            // what is the origin of this off-by-one?
-            expect(canvas.height).toEqual(document.body.offsetHeight - FULLSCREEN_PADDING + 1);
+            expect(canvas.height).toEqual(document.body.offsetHeight - FULLSCREEN_PADDING);
         });
     });
     describe('Mouse events', () => {

--- a/test/group.test.js
+++ b/test/group.test.js
@@ -52,15 +52,13 @@ describe('Groups', () => {
             g.add(group);
             g.redraw();
 
-            let context = g.getContext();
-            let topLeftPixel = context.getImageData(0, 0, 1, 1);
-            expect(topLeftPixel.data).toEqual(new Uint8ClampedArray([0, 0, 0, 128]));
+            let topLeftPixel = g.getPixel(0, 0);
+            expect(topLeftPixel).toEqual([0, 0, 0, 128]);
 
             group.add(r);
             g.redraw();
-            context = g.getContext();
-            topLeftPixel = context.getImageData(0, 0, 1, 1);
-            expect(topLeftPixel.data).toEqual(new Uint8ClampedArray([0, 0, 0, 128]));
+            topLeftPixel = g.getPixel(0, 0);
+            expect(topLeftPixel).toEqual([0, 0, 0, 128]);
         });
     });
     describe('Rotation', () => {
@@ -80,8 +78,8 @@ describe('Groups', () => {
             g.rotate(180);
             gfx.add(g);
             gfx.redraw();
-            const topLeftPixel = gfx.getContext().getImageData(0, 0, 1, 1);
-            expect(topLeftPixel.data).toEqual(new Uint8ClampedArray([0, 0, 255, 255]));
+            const topLeftPixel = gfx.getPixel(0, 0);
+            expect(topLeftPixel).toEqual([0, 0, 255, 255]);
         });
         it('Should rotate the entire content of the group around its center', () => {
             const g = new Group();
@@ -95,8 +93,8 @@ describe('Groups', () => {
             g.add(chartreuseRect);
             gfx.add(g);
             gfx.redraw();
-            const topLeftPixel = gfx.getContext().getImageData(0, 0, 1, 1);
-            expect(topLeftPixel.data).toEqual(new Uint8ClampedArray([127, 255, 0, 255]));
+            const topLeftPixel = gfx.getPixel(0, 0);
+            expect(topLeftPixel).toEqual([127, 255, 0, 255]);
         });
     });
     describe('Bounds calculations', () => {
@@ -204,13 +202,13 @@ describe('Groups', () => {
             gfx.add(g);
             gfx.redraw();
 
-            let topLeftPixel = gfx.getContext().getImageData(0, 0, 1, 1);
-            expect(topLeftPixel.data).toEqual(new Uint8ClampedArray([0, 0, 255, 255]));
+            let topLeftPixel = gfx.getPixel(0, 0);
+            expect(topLeftPixel).toEqual([0, 0, 255, 255]);
 
             red.layer = 2;
             gfx.redraw();
-            topLeftPixel = gfx.getContext().getImageData(0, 0, 1, 1);
-            expect(topLeftPixel.data).toEqual(new Uint8ClampedArray([255, 0, 0, 255]));
+            topLeftPixel = gfx.getPixel(0, 0);
+            expect(topLeftPixel).toEqual([255, 0, 0, 255]);
         });
     });
 });

--- a/test/oval.test.js
+++ b/test/oval.test.js
@@ -34,8 +34,8 @@ describe('Oval', () => {
             o.setPosition(20, 20);
             g.add(o);
             g.redraw();
-            const pixel = context.getImageData(20, 20, 1, 1);
-            expect(pixel.data).toEqual(new Uint8ClampedArray([255, 0, 0, 255]));
+            const pixel = g.getPixel(20, 20);
+            expect(pixel).toEqual([255, 0, 0, 255]);
         });
     });
     describe('containsPoint', () => {
@@ -73,30 +73,26 @@ describe('Oval', () => {
             // a circle at the top left should be placed exactly
             // at the origin, with the bottom right quadrant visible
             g.redraw();
-            let topLeftPixel = g.getContext().getImageData(0, 0, 1, 1);
-            expect(topLeftPixel.data).toEqual(new Uint8ClampedArray([255, 0, 0, 255]));
+            let topLeftPixel = g.getPixel(0, 0);
+            expect(topLeftPixel).toEqual([255, 0, 0, 255]);
 
             // a circle at the top left with anchor 0, 0 should be drawn
             // down and to the right of the origin, with its entire
             // self visible
             o.setAnchor({ vertical: 0, horizontal: 0 });
             g.redraw();
-            topLeftPixel = g.getContext().getImageData(0, 0, 1, 1);
-            expect(topLeftPixel.data).toEqual(new Uint8ClampedArray([0, 0, 0, 0]));
+            topLeftPixel = g.getPixel(0, 0);
+            expect(topLeftPixel).toEqual([0, 0, 0, 0]);
 
             o.setPosition(g.getWidth(), g.getHeight());
             o.setAnchor({ vertical: 1, horizontal: 1 });
             g.redraw();
-            let bottomRightPixel = g
-                .getContext()
-                .getImageData(g.getWidth() - 1, g.getHeight() - 1, 1, 1);
-            expect(bottomRightPixel.data).toEqual(new Uint8ClampedArray([0, 0, 0, 0]));
+            let bottomRightPixel = g.getPixel(g.getWidth() - 1, g.getHeight() - 1);
+            expect(bottomRightPixel).toEqual([0, 0, 0, 0]);
             o.setAnchor({ vertical: 0.5, horizontal: 0.5 });
             g.redraw();
-            bottomRightPixel = g
-                .getContext()
-                .getImageData(g.getWidth() - 1, g.getHeight() - 1, 1, 1);
-            expect(bottomRightPixel.data).toEqual(new Uint8ClampedArray([255, 0, 0, 255]));
+            bottomRightPixel = g.getPixel(g.getWidth() - 1, g.getHeight() - 1);
+            expect(bottomRightPixel).toEqual([255, 0, 0, 255]);
         });
     });
 

--- a/test/rectangle.test.js
+++ b/test/rectangle.test.js
@@ -14,8 +14,8 @@ describe('Rectangle', () => {
             g.add(r);
             g.redraw();
 
-            const topLeftPixel = g.getContext().getImageData(0, 0, 1, 1);
-            expect(topLeftPixel.data).toEqual(new Uint8ClampedArray([255, 0, 0, 255]));
+            const topLeftPixel = g.getPixel(0, 0);
+            expect(topLeftPixel).toEqual([255, 0, 0, 255]);
         });
         it('Will draw down and to the right of a 0, 0 (default) anchor', () => {
             const g = new Graphics();
@@ -25,14 +25,10 @@ describe('Rectangle', () => {
             r.setColor('red');
             g.add(r);
             g.redraw();
-            const bottomRightPixel = g
-                .getContext()
-                .getImageData(g.getWidth() - 1, g.getHeight() - 1, 1, 1);
-            expect(bottomRightPixel.data).toEqual(new Uint8ClampedArray([255, 0, 0, 255]));
-            const oobPixel = g
-                .getContext()
-                .getImageData(g.getWidth() - 11, g.getHeight() - 11, 1, 1);
-            expect(oobPixel.data).toEqual(new Uint8ClampedArray([0, 0, 0, 0]));
+            const bottomRightPixel = g.getPixel(g.getWidth() - 1, g.getHeight() - 1);
+            expect(bottomRightPixel).toEqual([255, 0, 0, 255]);
+            const oobPixel = g.getPixel(g.getWidth() - 11, g.getHeight() - 11);
+            expect(oobPixel).toEqual([0, 0, 0, 0]);
         });
         it('Affects containsPoint() calculations', () => {
             const r = new Rectangle(5, 5);

--- a/test/webimage.test.js
+++ b/test/webimage.test.js
@@ -36,13 +36,12 @@ describe('WebImage', () => {
             return new Promise((resolve, reject) => {
                 wi.loaded(() => {
                     g.redraw();
-                    const context = g.getContext();
-                    let topLeftPixel = context.getImageData(0, 0, 1, 1);
-                    expect(topLeftPixel.data).toEqual(new Uint8ClampedArray([255, 0, 0, 255]));
+                    let topLeftPixel = g.getPixel(0, 0);
+                    expect(topLeftPixel).toEqual([255, 0, 0, 255]);
                     wi.setPosition(50, 50);
                     g.redraw();
-                    topLeftPixel = context.getImageData(50, 50, 1, 1);
-                    expect(topLeftPixel.data).toEqual(new Uint8ClampedArray([255, 0, 0, 255]));
+                    topLeftPixel = g.getPixel(50, 50);
+                    expect(topLeftPixel).toEqual([255, 0, 0, 255]);
                     resolve();
                 });
             });
@@ -96,10 +95,8 @@ describe('WebImage', () => {
                 wi.loaded(() => {
                     wi.setPixel(0, 0, 0, 0);
                     g.redraw();
-                    const context = g.getContext();
-                    const topLeftPixel = context.getImageData(0, 0, 1, 1);
-                    const pixelData = topLeftPixel.data;
-                    expect(pixelData).toEqual(new Uint8ClampedArray([0, 0, 0, 255]));
+                    const topLeftPixel = g.getPixel(0, 0);
+                    expect(topLeftPixel).toEqual([0, 0, 0, 255]);
                     resolve();
                 });
             });
@@ -160,9 +157,8 @@ describe('WebImage', () => {
             g.add(img);
             img.setImageData(imageData);
             g.redraw();
-            const context = g.getContext();
-            const topLeftPixel = context.getImageData(0, 0, 1, 1);
-            expect(topLeftPixel.data).toEqual(new Uint8ClampedArray([0, 0, 255, 255]));
+            const topLeftPixel = g.getPixel(0, 0);
+            expect(topLeftPixel).toEqual([0, 0, 255, 255]);
         });
     });
     describe('setRed/Blue/Green/Alpha', () => {
@@ -192,13 +188,12 @@ describe('WebImage', () => {
             return new Promise((resolve, reject) => {
                 img.loaded(() => {
                     g.redraw();
-                    const context = g.getContext();
-                    let topLeftPixel = context.getImageData(0, 0, 1, 1);
-                    expect(topLeftPixel.data).toEqual(new Uint8ClampedArray([255, 0, 0, 255]));
+                    let topLeftPixel = g.getPixel(0, 0);
+                    expect(topLeftPixel).toEqual([255, 0, 0, 255]);
                     img.setRotation(180);
                     g.redraw();
-                    topLeftPixel = context.getImageData(0, 0, 1, 1);
-                    expect(topLeftPixel.data).toEqual(new Uint8ClampedArray([0, 0, 255, 255]));
+                    topLeftPixel = g.getPixel(0, 0);
+                    expect(topLeftPixel).toEqual([0, 0, 255, 255]);
                     resolve();
                 });
             });


### PR DESCRIPTION
## Summary
Devices with retina display draw a single pixel with more than one pixel, 2 in the case of my machine.
To provide high resolution drawing, the canvas is sized at 2x its dimensions, then shrunk back down using CSS. This is all done in `setSize`, and should never be visible to the user.
To keep this abstraction, graphics now exposes `getPixel`, which will return the pixel at an `x, y` position. This was needed exclusively for internal tests, but I can imagine per-pixel interactions coming up in the future with filters or cool effects.

## Changes
- `Graphics` now stores an internal `devicePixelRatio`
- `setSize` now sizes the canvas based on the `devicePixelRatio`, then performs CSS shrinking
- `setCurrentCanvas` calls `setSize` with the initial dimensions of the canvas to trigger the resize
- `getPixel` is now exposed and used in internal tests
- `calculateCoordinates` no longer calculates 
