### PR TITLE
Only build docs when a new release is published, not on push to main

### DIFF
--- a/.github/workflows/pages-build-and-publish.yml
+++ b/.github/workflows/pages-build-and-publish.yml
@@ -3,11 +3,9 @@
 name: GitHub pages
 
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [released]
     
-
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Docs were building on any push to `main`, which meant that the docs were sometimes out of sync with the latest release.
Ideally we can have versioned docs in the future, where each release keeps its documentation around, but for now this keeps things as accurate as possible.