### PR TITLE
Only set up TouchEvent handlers if defined on window

### DIFF
--- a/src/graphics/index.js
+++ b/src/graphics/index.js
@@ -825,12 +825,14 @@ MouseEvent.prototype.getY = function () {
     return calculateCoordinates(this).y;
 };
 
-TouchEvent.prototype.getX = function () {
-    return calculateCoordinates(this.touches[0]).x;
-};
+if (typeof TouchEvent) {
+    TouchEvent.prototype.getX = function () {
+        return calculateCoordinates(this.touches[0]).x;
+    };
 
-TouchEvent.prototype.getY = function () {
-    return calculateCoordinates(this.touches[0]).y;
-};
+    TouchEvent.prototype.getY = function () {
+        return calculateCoordinates(this.touches[0]).y;
+    };
+}
 
 export default GraphicsManager;


### PR DESCRIPTION
Fix for Safari—`TouchEvent` doesnt exist in Safari