### PR TITLE
Lazy-create keyboard navigable DOM elements

### DIFF
--- a/src/graphics/index.js
+++ b/src/graphics/index.js
@@ -444,7 +444,7 @@ class GraphicsManager extends Manager {
         }
         elem.alive = false;
         const focusButtonID = HIDDEN_KEYBOARD_NAVIGATION_DOM_ELEMENT_ID(elem._id);
-        document.getElementById(focusButtonID).remove();
+        document.getElementById(focusButtonID)?.remove();
     }
     /**
      * Set the size of the canvas.

--- a/src/graphics/index.js
+++ b/src/graphics/index.js
@@ -73,6 +73,12 @@ class GraphicsManager extends Manager {
             }
 
             if (e.key === 'Tab') {
+                for (let i = 0; i < this.elementPoolSize; i++) {
+                    const elem = this.elementPool[i];
+                    if (!elem._hasAccessibleDOMElement) {
+                        this.createAccessibleDOMElement(elem);
+                    }
+                }
                 this.userNavigatingWithKeyboard = true;
                 this.showKeyboardNavigationDOMElements();
             }
@@ -134,7 +140,6 @@ class GraphicsManager extends Manager {
     add(elem) {
         elem.alive = true;
         this.elementPool[this.elementPoolSize++] = elem;
-        this.createAccessibleDOMElement(elem);
     }
 
     /**
@@ -175,6 +180,7 @@ class GraphicsManager extends Manager {
         };
         document.body.appendChild(button);
         this.accessibleDOMElements.push(button);
+        elem._hasAccessibleDOMElement = true;
     }
 
     exitKeyboardNavigation() {

--- a/test/accessibility.test.js
+++ b/test/accessibility.test.js
@@ -12,6 +12,7 @@ describe('Keyboard navigation', () => {
             const g = new Graphics();
             const t = new Thing();
             g.add(t);
+            simulateEvent('keydown', { key: 'Tab' }, document.querySelector('#game'));
             const button = document.querySelector('button');
             expect(button).not.toBeNull();
             button.dispatchEvent(new Event('focus'));
@@ -21,9 +22,10 @@ describe('Keyboard navigation', () => {
             const g = new Graphics();
             const t = new Thing();
             g.add(t);
+            simulateEvent('keydown', { key: 'Tab' }, document.querySelector('#game'));
             const button = document.querySelector('button');
             expect(button.style.cssText.replace(/\s+/g, '')).toEqual(
-                HIDDEN_KEYBOARD_NAVIGATION_DOM_ELEMENT_STYLE.replace(/\s+/g, '')
+                KEYBOARD_NAVIGATION_DOM_ELEMENT_STYLE.replace(/\s+/g, '')
             );
         });
         it('Changes style when the graphics instance switches to keyboard navigation mode', () => {
@@ -40,6 +42,7 @@ describe('Keyboard navigation', () => {
             const g = new Graphics();
             const t = new Thing();
             g.add(t);
+            simulateEvent('keydown', { key: 'Tab' }, document.querySelector('#game'));
             let button = document.getElementById(HIDDEN_KEYBOARD_NAVIGATION_DOM_ELEMENT_ID(t._id));
             expect(button).not.toBeNull();
             g.remove(t);


### PR DESCRIPTION
## Summary
Programs that added a lot of elements were causing slowdowns when thousands of DOM elements were added. This doesn't add elements until the initial Tab press to prevent unneeded DOM elements