### PR TITLE
Cleanup for Graphics instances

### DIFF
--- a/docs/examples/graphics/keymethod.html
+++ b/docs/examples/graphics/keymethod.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Key Method</title>
+        <style>
+            canvas {
+                border: 1px solid black;
+            }
+        </style>
+    </head>
+    <body>
+        <canvas id="game" width="480" height="400"></canvas>
+        <script src="../../../../dist/chs.iife.js"></script>
+        <script id="code">
+            const t = new Text('Press a key to display its .key property');
+            t.setAnchor({ vertical: 0.5, horizontal: 0.5 });
+            t.setPosition(getWidth() / 2, getHeight() / 2);
+            add(t);
+
+            keyDownMethod(e => {
+                t.setLabel(e.key);
+            });
+        </script>
+        <p>This example shows how a keyDownMethod can be used to detect keypresses.</p>
+    </body>
+</html>

--- a/src/graphics/index.js
+++ b/src/graphics/index.js
@@ -13,8 +13,9 @@ export const HIDDEN_KEYBOARD_NAVIGATION_DOM_ELEMENT_ID = id => `${id}focusbutton
 
 /** @type {Object.<string, GraphicsManager>} */
 export let GraphicsInstances = {};
+/** @type {Array.<any>} */
+export let pressedKeys = [];
 let graphicsInstanceID = 0;
-let pressedKeys = [];
 
 /**
  * Class for interacting with Graphics.

--- a/src/graphics/index.js
+++ b/src/graphics/index.js
@@ -12,7 +12,7 @@ export const HIDDEN_KEYBOARD_NAVIGATION_DOM_ELEMENT_STYLE =
 export const HIDDEN_KEYBOARD_NAVIGATION_DOM_ELEMENT_ID = id => `${id}focusbutton`;
 
 /** @type {Object.<string, GraphicsManager>} */
-let GraphicsInstances = {};
+export let GraphicsInstances = {};
 let graphicsInstanceID = 0;
 let pressedKeys = [];
 
@@ -65,61 +65,82 @@ class GraphicsManager extends Manager {
         GraphicsInstances[graphicsInstanceID++] = this;
     }
 
-    addEventListeners() {
-        window.addEventListener('keydown', e => {
-            const index = pressedKeys.indexOf(e.keyCode);
-            if (index === -1) {
-                pressedKeys.push(e.keyCode);
-            }
+    onKeyDown = e => {
+        const index = pressedKeys.indexOf(e.keyCode);
+        if (index === -1) {
+            pressedKeys.push(e.keyCode);
+        }
 
-            if (e.key === 'Tab') {
-                for (let i = 0; i < this.elementPoolSize; i++) {
-                    const elem = this.elementPool[i];
-                    if (!elem._hasAccessibleDOMElement) {
-                        this.createAccessibleDOMElement(elem);
-                    }
+        if (e.key === 'Tab') {
+            for (let i = 0; i < this.elementPoolSize; i++) {
+                const elem = this.elementPool[i];
+                if (!elem._hasAccessibleDOMElement) {
+                    this.createAccessibleDOMElement(elem);
                 }
-                this.userNavigatingWithKeyboard = true;
-                this.showKeyboardNavigationDOMElements();
             }
+            this.userNavigatingWithKeyboard = true;
+            this.showKeyboardNavigationDOMElements();
+        }
 
-            this.keyDownCallback?.(e);
-            return true;
-        });
+        this.keyDownCallback?.(e);
+        return true;
+    };
 
-        window.addEventListener('keyup', e => {
-            const index = pressedKeys.indexOf(e.keyCode);
-            if (index !== -1) {
-                pressedKeys.splice(index, 1);
-            }
-            this.keyUpCallback?.(e);
-        });
+    onKeyUp = e => {
+        const index = pressedKeys.indexOf(e.keyCode);
+        if (index !== -1) {
+            pressedKeys.splice(index, 1);
+        }
+        this.keyUpCallback?.(e);
+    };
 
-        let resizeTimeout;
-        window.addEventListener('resize', e => {
-            // https://developer.mozilla.org/en-US/docs/Web/Events/resize
-            // Throttle the resize event handler since it fires at such a rapid rate
-            // Only respond to the resize event if there's not already a response queued up
-            if (!resizeTimeout) {
-                resizeTimeout = setTimeout(() => {
-                    resizeTimeout = null;
-                    this.fullscreenMode && this.setFullscreen?.();
-                }, DEFAULT_UPDATE_INTERVAL);
-            }
-        });
+    onResize = e => {
+        // https://developer.mozilla.org/en-US/docs/Web/Events/resize
+        // Throttle the resize event handler since it fires at such a rapid rate
+        // Only respond to the resize event if there's not already a response queued up
+        if (!this._resizeTimeout) {
+            this._resizeTimeout = setTimeout(() => {
+                this._resizeTimeout = null;
+                this.fullscreenMode && this.setFullscreen?.();
+            }, DEFAULT_UPDATE_INTERVAL);
+        }
+    };
+
+    onOrientationChange = e => {
+        this.deviceOrientationCallback?.(e);
+    };
+
+    onDeviceMotion = e => {
+        this.deviceMotionCallback?.(e);
+    };
+
+    /**
+     * Add all handlers to the window for triggering functions on the instance.
+     */
+    addEventListeners() {
+        window.addEventListener('keydown', this.onKeyDown);
+        window.addEventListener('keyup', this.onKeyUp);
+        window.addEventListener('resize', this.onResize);
 
         /** MOBILE DEVICE EVENTS ****/
         if (window.DeviceOrientationEvent) {
-            window.addEventListener('orientationchange', e => {
-                this.deviceOrientationCallback?.(e);
-            });
+            window.addEventListener('orientationchange', this.onOrientationChange);
         }
 
         if (window.DeviceMotionEvent) {
-            window.addEventListener('devicemotion', e => {
-                this.deviceMotionCallback?.(e);
-            });
+            window.addEventListener('devicemotion', this.onDeviceMotion);
         }
+    }
+
+    /**
+     * Remove all handlers from the window and clean up any memory.
+     */
+    cleanup() {
+        window.removeEventListener('keydown', this.onKeyDown);
+        window.removeEventListener('keyup', this.onKeyUp);
+        window.removeEventListener('resize', this.onResize);
+        window.removeEventListener('orientationchange', this.onOrientationChange);
+        window.removeEventListener('devicemotion', this.onDeviceMotion);
     }
 
     configure(options = {}) {

--- a/test/graphics.test.js
+++ b/test/graphics.test.js
@@ -472,4 +472,15 @@ describe('Graphics', () => {
             expect(map(50, 0, 100, 0, 4)).toEqual(2);
         });
     });
+    describe('cleanup()', () => {
+        it('Removes all handlers', () => {
+            const g = new Graphics();
+            const keyDownSpy = spyOn(g, 'onKeyDown');
+            simulateEvent('keydown', {}, document.querySelector('#game'));
+            expect(keyDownSpy).toHaveBeenCalled();
+            g.cleanup();
+            simulateEvent('keydown', {}, document.querySelector('#game'));
+            expect(keyDownSpy).toHaveBeenCalledTimes(1);
+        });
+    });
 });

--- a/test/graphics.test.js
+++ b/test/graphics.test.js
@@ -1,5 +1,5 @@
 import Circle from '../src/graphics/circle.js';
-import Graphics, { FULLSCREEN_PADDING } from '../src/graphics/index.js';
+import Graphics, { FULLSCREEN_PADDING, pressedKeys } from '../src/graphics/index.js';
 import Rectangle from '../src/graphics/rectangle.js';
 import { map } from '../src/graphics/graphics-utils.js';
 
@@ -475,12 +475,11 @@ describe('Graphics', () => {
     describe('cleanup()', () => {
         it('Removes all handlers', () => {
             const g = new Graphics();
-            const keyDownSpy = spyOn(g, 'onKeyDown');
-            simulateEvent('keydown', {}, document.querySelector('#game'));
-            expect(keyDownSpy).toHaveBeenCalled();
+            simulateEvent('keydown', { keyCode: 'testkey' }, window);
+            expect(pressedKeys).toContain('testkey');
             g.cleanup();
-            simulateEvent('keydown', {}, document.querySelector('#game'));
-            expect(keyDownSpy).toHaveBeenCalledTimes(1);
+            simulateEvent('keydown', { keyCode: 'test2' }, window);
+            expect(pressedKeys).not.toContain('test2');
         });
     });
 });

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,3 +1,5 @@
+import { GraphicsInstances } from '../src/graphics/index.js';
+
 function setup() {
     const canvas = document.createElement('canvas');
     canvas.id = 'game';
@@ -12,6 +14,9 @@ beforeEach(() => {
 
 afterEach(() => {
     document.body.innerHTML = '';
+    Object.entries(GraphicsInstances).forEach(([id, instance]) => {
+        instance.cleanup();
+    });
 });
 
 setup();


### PR DESCRIPTION
## Summary
There were issues where tests would fail because Graphics instances were leaving their event listeners on the window, which was causing later tests to trigger behavior for previous Graphics instances.

This fixes that by adding a `.cleanup` method that removes handlers and uses that method in `afterEach` of tests