### PR TITLE
Builds docs and public page on push to main, not just on release

### DIFF
--- a/.github/workflows/pages-build-and-publish.yml
+++ b/.github/workflows/pages-build-and-publish.yml
@@ -3,8 +3,8 @@
 name: GitHub pages
 
 on:
-  release:
-    types: [released]
+  push:
+    branches: [ main ]
     
 jobs:
   deploy:


### PR DESCRIPTION
This can lead to some out-of-sync issues with releases and docs, but that should probably be resolved with a development branch. This should let docs be updated without needing to go through a full release.