### PR TITLE
Support printing multiple elements with `print` to prepare for printing objects.

### DIFF
--- a/src/console/index.js
+++ b/src/console/index.js
@@ -72,28 +72,24 @@ export default class CodeHSConsole {
     }
 
     /**
-     * Print a line to the console.
-     * @param {string} ln - The string to print.
+     * Print a value to the console.
+     * @param {...any} args - Anything to print.
      */
-    print(ln) {
-        if (arguments.length !== 1) {
-            throw new Error('You should pass exactly 1 argument to print');
-        }
-        this.onPrint(ln);
+    print(...args) {
+        this.onPrint(...args);
     }
 
     /**
-     * Print a line to the console.
-     * @param {string} ln - The string to print.
+     * Print a value to the console, followed by a newline character.
+     * @param {any} value - The value to print.
      */
-    println(ln) {
+    println(value) {
         if (arguments.length === 0) {
-            ln = '';
+            value = '';
         } else if (arguments.length !== 1) {
             throw new Error('You should pass exactly 1 argument to println');
         }
-
-        this.print(ln + '\n');
+        this.print(value, '\n');
     }
 
     /**

--- a/src/console/index.js
+++ b/src/console/index.js
@@ -10,7 +10,7 @@
  *
  */
 
-export default class CodeHSConsole {
+export default class Console {
     /**
      * Initialize the console class, additionally configuring any event handlers.
      * @constructor
@@ -76,6 +76,9 @@ export default class CodeHSConsole {
      * @param {...any} args - Anything to print.
      */
     print(...args) {
+        if (args.length < 1) {
+            throw new Error('You should pass at least 1 argument to print');
+        }
         this.onPrint(...args);
     }
 

--- a/test/console.test.js
+++ b/test/console.test.js
@@ -235,7 +235,7 @@ describe('Console', () => {
                 const c = new Console();
                 expect(() => {
                     c.print();
-                }).toThrow(Error('You should pass exactly 1 argument to print'));
+                }).toThrow(Error('You should pass at least 1 argument to print'));
             });
             it("Doesn't add a newline to its output", () => {
                 const c = new Console();
@@ -262,14 +262,14 @@ describe('Console', () => {
                 const printSpy = jasmine.createSpy();
                 c.configure({ onPrint: printSpy });
                 c.println();
-                expect(printSpy).toHaveBeenCalledOnceWith('\n');
+                expect(printSpy).toHaveBeenCalledOnceWith('', '\n');
             });
             it('Adds a newline to its output', () => {
                 const c = new Console();
                 const printSpy = jasmine.createSpy();
                 c.configure({ onPrint: printSpy });
                 c.println('Hello!');
-                expect(printSpy).toHaveBeenCalledOnceWith('Hello!\n');
+                expect(printSpy).toHaveBeenCalledOnceWith('Hello!', '\n');
             });
         });
     });


### PR DESCRIPTION
This prevents string concatenation with an object, so `println({a: 1})` can be handled by the caller as `[{a: 1}, '\n']` rather than as `['[object Object]']`