### PR TITLE
Fix for local site with types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@ _site/
 coverage
 site/assets/chs.iife.js
 site/assets/chs.mjs
+site/assets/chs.iife.min.js
+site/assets/chs.min.mjs
+site/assets/types.d.ts
+site/assets/src/
+site/assets/entrypoints/

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "build": "node build.js",
         "dev": "node build.js watch",
         "dist": "tsc && node build.js dist",
-        "docs": "npm run build && cp dist/* ./site/assets/ && jsdoc src/**/*.js --template node_modules/docdash --destination _site/docs",
+        "docs": "npm run build && cp -r dist/* ./site/assets/ && jsdoc src/**/*.js --template node_modules/docdash --destination _site/docs",
         "prepare": "husky install",
         "site": "npm run docs && npx @11ty/eleventy",
         "site:watch": "npm run docs && npx @11ty/eleventy --watch"


### PR DESCRIPTION
The build artifacts now include a directory, so the script to build docs needs to handle that.