### PR TITLE
Fix 2d Perlin noise implementation to handle boundary cases

### DIFF
--- a/site/examples/randomizer/2dnoise/2dnoise.js
+++ b/site/examples/randomizer/2dnoise/2dnoise.js
@@ -5,8 +5,12 @@ for (let row = 0; row < getHeight(); row++) {
         const scaledCol = col * 0.02;
         const pxl = new Rectangle(1, 1);
         pxl.setPosition(col, row);
-        const n = Randomizer.noise(scaledCol, scaledRow);
+        const n = Randomizer.noise(50 + scaledCol, 50 + scaledRow);
         pxl.setColor(Color.createFromRGB(n * 255, n * 255, n * 255));
         add(pxl);
     }
 }
+
+// save the CPU from needing to draw so many squares again
+__graphics__.redraw();
+__graphics__.shouldUpdate = false;

--- a/site/examples/randomizer/2dnoise/2dnoise.md
+++ b/site/examples/randomizer/2dnoise/2dnoise.md
@@ -2,6 +2,8 @@
 title: Randomizer - 2D Noise
 layout: example
 code: 2dnoise.js
+width: 200
+height: 400
 ---
 
 Passing a second argument to `noise` will create 2-dimensional noise.

--- a/src/randomizer.js
+++ b/src/randomizer.js
@@ -142,23 +142,24 @@ export const noise = (x, y) => {
          */
 
         const x0 = Math.floor(x) % PERLIN_SIZE_2D;
-        const x1 = x0 + 1;
+        const x1 = (x0 + 1) % PERLIN_SIZE_2D;
         const y0 = Math.floor(y) % PERLIN_SIZE_2D;
-        const y1 = y0 + 1;
+        const y1 = (y0 + 1) % PERLIN_SIZE_2D;
 
-        const dx = x - x0;
-        const dy = y - y0;
+        // dx and dy represent the local position of the x, y pair within the perlin unit space
+        // because the case of wrapping around (x is 63 and x0 is 0), they must be restricted with modulus
+        const dx = (x - x0) % PERLIN_SIZE_2D;
+        const dy = (y - y0) % PERLIN_SIZE_2D;
 
         const gradientTL = perlin2[x0][y0];
         const gradientTR = perlin2[x1][y0];
         const gradientBL = perlin2[x0][y1];
         const gradientBR = perlin2[x1][y1];
 
-        const noiseTL = gradientTL.dot(x - x0, y - y0);
-        const noiseTR = gradientTR.dot(x - x1, y - y0);
-        const noiseBL = gradientBL.dot(x - x0, y - y1);
-        const noiseBR = gradientBR.dot(x - x1, y - y1);
-
+        const noiseTL = gradientTL.dot(dx, dy);
+        const noiseTR = gradientTR.dot(dx - 1, dy);
+        const noiseBL = gradientBL.dot(dx, dy - 1);
+        const noiseBR = gradientBR.dot(dx - 1, dy - 1);
         const xFade = fade(dx);
 
         return (

--- a/test/randomizer.test.js
+++ b/test/randomizer.test.js
@@ -48,5 +48,14 @@ describe('Randomizer', () => {
                 expect(Randomizer.noise(x2) - Randomizer.noise(x1)).toBeLessThan(0.2);
             }
         });
+        describe('2d noise', () => {
+            it('Is continuous past PERLIN_SIZE_2D', () => {
+                for (let i = 0; i < 127; i += 0.01) {
+                    const x1 = i;
+                    const x2 = i + 0.01;
+                    expect(Randomizer.noise(x2, x2) - Randomizer.noise(x1, x1)).toBeLessThan(0.1);
+                }
+            });
+        });
     });
 });


### PR DESCRIPTION
## Summary
At the boundaries of the pre-computed 2d gradient array the noise values produced would be far outside of 0->1, producing interesting bugs like this one:
![badwater](https://user-images.githubusercontent.com/6645121/150585591-aa1c5b77-00f5-4765-9e36-6cb7e99118d1.gif)

The bug was caused by large `dx` and `dy` values being calculated and used in the dot products with the 4 gradient vectors.

In the case where `x` was 63, `x0` would be 0 and `dx` would be `x - x0` (63).
This is now resolved by making sure that `dx` and `dy` respect the boundary of `PERLIN_NOISE_2D`, that `x1` and `y1` (the bottom and right edges of the cell in the Perlin unit space) will properly wrap, and that the dot products are calculated using `dy - 1` and `dx - 1` rather than `y - y1` etc to prevent these out of bounds issues.

