### PR TITLE
Fixes for input re-prompting

### DIFF
--- a/entrypoints/windowBinder.js
+++ b/entrypoints/windowBinder.js
@@ -75,6 +75,8 @@ window.setSize = GraphicsInstance.setSize.bind(GraphicsInstance);
 const ConsoleInstance = new Console();
 window.readLine = ConsoleInstance.readLine.bind(ConsoleInstance);
 window.readInt = ConsoleInstance.readInt.bind(ConsoleInstance);
+window.println = ConsoleInstance.println.bind(ConsoleInstance);
+window.print = ConsoleInstance.print.bind(ConsoleInstance);
 
 const AudioInstance = new AudioManager();
 window.audioChangeMethod = AudioInstance.audioChangeMethod.bind(AudioInstance);

--- a/site/examples/console/readInt/readInt.js
+++ b/site/examples/console/readInt/readInt.js
@@ -1,3 +1,3 @@
-setTimeout(() => {
-    alert(readInt('Give me a number! ') * 12);
-}, 0);
+let x = readInt('Give me an x: ');
+let y = readInt('Give me a y: ');
+println('The y/x = ' + y / x);

--- a/test/console.test.js
+++ b/test/console.test.js
@@ -132,8 +132,8 @@ describe('Console', () => {
                 expect(promptSpy).toHaveBeenCalledTimes(3);
                 expect(promptSpy.calls.allArgs()).toEqual([
                     ['Give me a float: '],
-                    ['That was not a float. Please try again. Give me a float: '],
-                    ['That was not a float. Please try again. Give me a float: '],
+                    ["'one' was not a float. Please try again.\nGive me a float: "],
+                    ["'two' was not a float. Please try again.\nGive me a float: "],
                 ]);
                 expect(int).toBe(3.0);
             });
@@ -159,8 +159,8 @@ describe('Console', () => {
                 expect(promptSpy).toHaveBeenCalledTimes(3);
                 expect(promptSpy.calls.allArgs()).toEqual([
                     ['Give me a number: '],
-                    ['That was not an integer. Please try again. Give me a number: '],
-                    ['That was not an integer. Please try again. Give me a number: '],
+                    ["'one' was not an integer. Please try again.\nGive me a number: "],
+                    ["'two' was not an integer. Please try again.\nGive me a number: "],
                 ]);
                 expect(int).toBe(3);
             });
@@ -222,8 +222,8 @@ describe('Console', () => {
                 expect(promptSpy).toHaveBeenCalledTimes(3);
                 expect(promptSpy.calls.allArgs()).toEqual([
                     ['Give me a bool: '],
-                    ['That was not a boolean (true/false). Please try again. Give me a bool: '],
-                    ['That was not a boolean (true/false). Please try again. Give me a bool: '],
+                    ["'nope' was not a boolean (true/false). Please try again.\nGive me a bool: "],
+                    ["'yep' was not a boolean (true/false). Please try again.\nGive me a bool: "],
                 ]);
                 expect(bool).toBeTrue();
             });


### PR DESCRIPTION
When prompting with readInt, readFloat, or readBoolean, correctly re-prompt the user with the output from the failing prompt

<!--

Thank you for contributing! Please use this pull request (PR) template.
In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing.
If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".

-->

## Summary
Input re-prompts weren't including the latest incorrect input in the prompt. This fixes that, as well as simplifying how `readNumber` works.
`readLine` behaves separately, since it doesn't have a parseFn, so I'm just duplicating the behavior of printing the prompt then output there.

## Changes:
<!--
Include what specific changes were made in this pull request.
-->
- expose print and println in windowbinding entrypoint
- properly include failed prompt in output 

## Screenshots of the change:
<!--
If applicable, add screenshots depicting the changes.
-->
![image](https://user-images.githubusercontent.com/6645121/151412331-c6fb4a05-775b-45c7-a84f-a1235f57ccc1.png)


## Checklist
<!--
To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab!
Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm test` passes
- [x] Unit tests are included / updated
- [x] Documentation has been updated where relevant

<!-- Pull Request Template from p5.js https://github.com/processing/p5.js/blob/main/.github/PULL_REQUEST_TEMPLATE.md -->
