### PR TITLE
Stop all timers with the same name when calling `stopTimer`

### DIFF
--- a/src/manager.js
+++ b/src/manager.js
@@ -11,6 +11,7 @@ class Manager {
      */
     constructor(options = {}) {
         this.onError = options.onError;
+        /** @type {Object.<string, Array.<Function>>} */
         this.timers = {};
     }
 
@@ -76,7 +77,11 @@ class Manager {
             };
         })();
 
-        this.timers[name] = stop;
+        if (this.timers[name]) {
+            this.timers[name].push(stop);
+        } else {
+            this.timers[name] = [stop];
+        }
     }
 
     /**
@@ -86,8 +91,8 @@ class Manager {
      */
     stopTimer(fn) {
         const name = typeof fn === 'function' ? fn.name : fn;
-        this.timers[name]?.();
-        this.timers[name] = null;
+        this.timers[name]?.forEach(stopper => stopper());
+        this.timers[name] = [];
     }
 
     /**

--- a/test/graphics.test.js
+++ b/test/graphics.test.js
@@ -395,6 +395,24 @@ describe('Graphics', () => {
                         });
                     });
                 });
+                describe('Timer collision', () => {
+                    it('Multiple timers with the same name will all be stopped', () => {
+                        const timerOneSpy = jasmine.createSpy();
+                        const timerTwoSpy = jasmine.createSpy();
+                        const g = new Graphics();
+                        g.setTimer(timerOneSpy, 15, {}, 'sharedname');
+                        g.setTimer(timerTwoSpy, 15, {}, 'sharedname');
+                        g.stopAllTimers();
+                        return new Promise(resolve => {
+                            setTimeout(() => {
+                                expect(timerOneSpy).not.toHaveBeenCalled();
+                                expect(timerTwoSpy).not.toHaveBeenCalled();
+                                resolve();
+                            }, 100);
+                        });
+                        expect();
+                    });
+                });
             });
         });
     });


### PR DESCRIPTION
<!--

Thank you for contributing! Please use this pull request (PR) template.
In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing.
If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".

-->
Resolves #108

## Summary
<!--
Include a summary of your changes. What problem are you addressing, and how does this solution addres it?
-->
Previously, if multiple timers were created with the same name, a call to `stopTimer` would only remove the most recently set one. This stores timers in an array so that calls to `stopTimer` can stop every timer with the same name.

## Changes:
<!--
Include what specific changes were made in this pull request.
-->
- Managers now store timers as an object of arrays
- Invoking `stopTimer` will now stop all timers with the same name


## Checklist
<!--
To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab!
Feel free to remove any portion of the template that is not relevant for your issue.
-->
- [x] `npm test` passes
- [x] Unit tests are included / updated
- [x] Documentation has been updated where relevant

<!-- Pull Request Template from p5.js https://github.com/processing/p5.js/blob/main/.github/PULL_REQUEST_TEMPLATE.md -->
