### PR TITLE
GitHub action for beta releases

### DIFF
--- a/.github/workflows/npm-beta-publish.yml
+++ b/.github/workflows/npm-beta-publish.yml
@@ -1,0 +1,24 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+
+name: Node.js Package
+
+on:
+  push:
+    branches:
+      - beta-release
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm run dist
+      - run: npm publish --tag beta
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
<!--

Thank you for contributing! Please use this pull request (PR) template.
In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing.
If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".

-->
## Summary
This is an experimental change that will set up a GitHub action for publishing a version with the `beta` tag when something pushes to the `beta-release` branch.
I believe the version in package.json will still need to be manually changed (`0.2.1-beta.x`, for example), but that process can be simplified later if it's needed.

## Changes:
- New GitHub action for publishing a beta tagged version of the library
- Created a new branch, `beta-release`

## Checklist
<!--
To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab!
Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm test` passes
- [x] Unit tests are included / updated
- [ ] Documentation has been updated where relevant

I'll update documentation when I know this process actually works!