### PR TITLE
Handle edge cases from add()ing elements twice

### DIFF
--- a/test/graphics.test.js
+++ b/test/graphics.test.js
@@ -276,6 +276,32 @@ describe('Graphics', () => {
             expect(g.elementPool[1].alive).toBeTrue();
             expect(g.elementPool[2].alive).toBeFalse();
         });
+        it('Properly handles duplicated elements', () => {
+            const g = new Graphics({ shouldUpdate: false });
+            const a = new Circle(1);
+            const b = new Circle(1);
+            const c = new Circle(1);
+            g.add(a);
+            g.add(b);
+            g.add(c);
+            g.add(a);
+            expect(g.elementPool).toEqual([a, b, c, a]);
+            expect(g.elementPoolSize).toEqual(4);
+            g.remove(a);
+            expect(g.elementPool).toEqual([a, b, c, a]);
+            expect(g.elementPoolSize).toEqual(4);
+            g.redraw();
+            expect(g.elementPool).toEqual([b, c, a, a]);
+            expect(g.elementPoolSize).toEqual(2);
+            g.add(a);
+            g.redraw();
+            expect(g.elementPool).toEqual([b, c, a, a]);
+            expect(g.elementPoolSize).toEqual(3);
+            a.layer = -1;
+            g.redraw();
+            expect(g.elementPool).toEqual([a, a, b, c]);
+            expect(g.elementPoolSize).toEqual(4);
+        });
     });
     describe('setBackgroundColor', () => {
         it('Causes drawBackground to be invoked in redraw()', () => {


### PR DESCRIPTION
<!--

Thank you for contributing! Please use this pull request (PR) template.
In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing.
If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".

-->
Resolves #120 

## Summary
<!--
Include a summary of your changes. What problem are you addressing, and how does this solution addres it?
-->
This fixes a unique edge case that could pop up if an element was `add()`ed twice. Adding an element only expands `elementPoolSize` by one, but after `remove()`ing that element, subsequent `add()`s would cause all duplicates to become active at once. 

## Changes:
<!--
Include what specific changes were made in this pull request.
-->
- Mark elements as `_sortInvalidated` when they're `remove()`d so that any subsequent `add()`s re-trigger a sort
- When sorting elements in `redraw`, rather than counting the number of elements removed to shrink `elementPoolSize`, recalculate `elementPoolSize` by finding the last non-`.alive` element. This fixes the case where multiple elements are added back with a single `add` and `elementPoolSize` needs to be recalculated.

## Checklist
<!--
To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab!
Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm test` passes
- [x] Unit tests are included / updated
- [x] Documentation has been updated where relevant

<!-- Pull Request Template from p5.js https://github.com/processing/p5.js/blob/main/.github/PULL_REQUEST_TEMPLATE.md -->
