### PR TITLE
Use action from Marketplace to extract the version of the package

### DIFF
--- a/.github/workflows/s3-publish.yml
+++ b/.github/workflows/s3-publish.yml
@@ -20,9 +20,9 @@ jobs:
       - run: npm ci
       - run: npm run dist
 
-      - name: Package Version
-        id: pkgversion
-        run: echo "::set-output name=PKG_VERSION::`npm view . version`"
+      - name: Extract version
+        id: extract_version
+        uses: Saionaro/extract-package-version@v1.0.6
 
       - uses: shallwefootball/s3-upload-action@master
         name: Upload S3
@@ -32,4 +32,4 @@ jobs:
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
           aws_bucket: ${{ secrets.AWS_BUCKET }}
           source_dir: 'dist'
-          destination_dir: 'chs-js-lib/${{ steps.pkgversion.outputs.PKG_VERSION }}/dist/'
+          destination_dir: 'chs-js-lib/${{ steps.extract_version.outputs.version }}/dist/'


### PR DESCRIPTION
Internal change, making sure that when the library publishes to npm it uses the version of the package currently listed in package.json.