### PR TITLE
Make remove() flexible by allowing non-Things to be removed

### DIFF
--- a/src/graphics/index.js
+++ b/src/graphics/index.js
@@ -462,6 +462,10 @@ class GraphicsManager extends Manager {
      * @param {Thing} elem - The element to be removed from the canvas.
      */
     remove(elem) {
+        if (!(elem instanceof Thing)) {
+            return;
+        }
+
         if (elem instanceof WebVideo) {
             elem.stop();
         }

--- a/test/graphics.test.js
+++ b/test/graphics.test.js
@@ -302,6 +302,19 @@ describe('Graphics', () => {
             expect(g.elementPool).toEqual([a, a, b, c]);
             expect(g.elementPoolSize).toEqual(4);
         });
+        it('Removing an undefined element does not throw', () => {
+            const g = new Graphics({ shouldUpdate: false });
+            let el;
+            expect(() => {
+                g.remove(el);
+            }).not.toThrow();
+        });
+        it('Removing a non-Thing does not throw', () => {
+            const g = new Graphics({ shouldUpdate: false });
+            expect(() => {
+                g.remove(Circle);
+            }).not.toThrow();
+        });
     });
     describe('fullReset', () => {
         it('Clears all elements', () => {


### PR DESCRIPTION
<!--

Thank you for contributing! Please use this pull request (PR) template.
In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing.
If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".

-->
Resolves #121 

## Summary
<!--
Include a summary of your changes. What problem are you addressing, and how does this solution addres it?
-->
This fixes an inconsistency between the legacy version of this library and the current version. In the legacy version, calling `remove(x)` if `x === undefined` would not error. Due to the way that removal works in this version, this would throw.

## Changes:
<!--
Include what specific changes were made in this pull request.
-->
- Add guards for removing `undefined` or non-`Thing`s


## Checklist
<!--
To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab!
Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm test` passes
- [x] Unit tests are included / updated
- [x] Documentation has been updated where relevant

<!-- Pull Request Template from p5.js https://github.com/processing/p5.js/blob/main/.github/PULL_REQUEST_TEMPLATE.md -->
