### PR TITLE
Update Polygons' bounding box calculations

### DIFF
--- a/src/graphics/polygon.js
+++ b/src/graphics/polygon.js
@@ -215,6 +215,35 @@ class Polygon extends Thing {
         const dy = y - this.y;
         this.move(dx, dy);
     }
+
+    /**
+     * Polygons manually calculate their bounds with their own implementation of _updateBounds
+     * (rather than the implementation in the Thing superclass) because Polygon's can have
+     * negative points which draw to the left of their x value or above their y value.
+     * @private
+     */
+    _updateBounds() {
+        let minX = Infinity;
+        let maxX = -Infinity;
+        let minY = Infinity;
+        let maxY = -Infinity;
+        this.points.forEach(({ x, y }) => {
+            minX = Math.min(minX, x);
+            maxX = Math.max(maxX, x);
+            minY = Math.min(minY, y);
+            maxY = Math.max(maxY, y);
+        });
+        const width = maxX - minX;
+        const height = maxY - minY;
+        this.bounds = {
+            left: minX - this.anchor.horizontal * width,
+            right: maxX - this.anchor.horizontal * width,
+            top: minY - this.anchor.vertical * height,
+            bottom: maxY - this.anchor.vertical * height,
+        };
+        this._boundsInvalidated = false;
+        this._lastCalculatedBoundsID++;
+    }
 }
 
 export default Polygon;

--- a/src/graphics/thing.js
+++ b/src/graphics/thing.js
@@ -482,7 +482,13 @@ class Thing {
             context.strokeStyle = 'red';
             context.fill();
             const bounds = this.getBounds();
-            context.strokeRect(0, 0, bounds.right - bounds.left, bounds.bottom - bounds.top);
+            context.translate(-drawX, -drawY);
+            context.strokeRect(
+                bounds.left,
+                bounds.top,
+                bounds.right - bounds.left,
+                bounds.bottom - bounds.top
+            );
         }
 
         context.restore();

--- a/test/polygon.test.js
+++ b/test/polygon.test.js
@@ -88,4 +88,26 @@ describe('Polygon', () => {
             ]);
         });
     });
+    describe('Bounds', () => {
+        it('Handles negative points', () => {
+            const p = new Polygon();
+            p.addPoint(-30, 0);
+            p.addPoint(0, 30);
+            p.addPoint(30, 30);
+
+            expect(p.getBounds()).toEqual({
+                top: 0,
+                left: -30,
+                bottom: 30,
+                right: 30,
+            });
+            p.setAnchor({ vertical: 0.5, horizontal: 0.5 });
+            expect(p.getBounds()).toEqual({
+                top: -15,
+                left: -60,
+                bottom: 15,
+                right: 0,
+            });
+        });
+    });
 });


### PR DESCRIPTION
<!--

Thank you for contributing! Please use this pull request (PR) template.
In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing.
If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".

-->
Resolves #119 

## Summary
<!--
Include a summary of your changes. What problem are you addressing, and how does this solution addres it?
-->
This updates the way Polygon's bounding boxes are calculated to account for the possibility of negative points. Additionally, when drawing bounding boxes in debug mode, draw the absolute bounds rather than a square with the width/height of the AABB around the x,y position to account for the possibility of negative points.

## Changes:
<!--
Include what specific changes were made in this pull request.
-->
- Polygon now implements `_updateBounds` to manually calculate its bounding box
- Thing's `draw` method now will draw a debug bounding box with no context translation at the bounds' position. This is to handle negative coordinates (relative to the shapes' x, y position) in the bounding box.

## Screenshots of the change:
<!--
If applicable, add screenshots depicting the changes.
-->
![polyspin](https://user-images.githubusercontent.com/6645121/155034660-920a8b19-b23c-4292-a5b2-65d557a3436b.gif)


## Checklist
<!--
To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab!
Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm test` passes
- [x] Unit tests are included / updated
- [x] Documentation has been updated where relevant

<!-- Pull Request Template from p5.js https://github.com/processing/p5.js/blob/main/.github/PULL_REQUEST_TEMPLATE.md -->
