### PR TITLE
Webimage setImage race condition

### DIFF
--- a/site/examples/graphics/webimage/setimage/setimage.js
+++ b/site/examples/graphics/webimage/setimage/setimage.js
@@ -1,0 +1,8 @@
+var img = new WebImage('https://codehs.com/uploads/056e56f7b32cdc9ed21c681c31166108');
+img.setAnchor({ vertical: 0.5, horizontal: 0.5 });
+img.setPosition(getWidth() / 2, getHeight() / 2);
+add(img);
+
+mouseClickMethod(e => {
+    img.setImage('https://codehs.com/uploads/1e38851d76e7691d923a3d3f3f7eae1d');
+});

--- a/site/examples/graphics/webimage/setimage/setimage.js
+++ b/site/examples/graphics/webimage/setimage/setimage.js
@@ -3,6 +3,4 @@ img.setAnchor({ vertical: 0.5, horizontal: 0.5 });
 img.setPosition(getWidth() / 2, getHeight() / 2);
 add(img);
 
-mouseClickMethod(e => {
-    img.setImage('https://codehs.com/uploads/1e38851d76e7691d923a3d3f3f7eae1d');
-});
+img.setImage('https://codehs.com/uploads/1e38851d76e7691d923a3d3f3f7eae1d');

--- a/site/examples/graphics/webimage/setimage/setimage.md
+++ b/site/examples/graphics/webimage/setimage/setimage.md
@@ -1,0 +1,9 @@
+---
+title: WebImage - setImage
+layout: example
+code: setimage.js
+width: 500
+height: 500
+---
+
+You can replace the image content of a `WebImage` using `setImage()`

--- a/site/examples/index.html
+++ b/site/examples/index.html
@@ -176,6 +176,9 @@ layout: base
                 <a href="graphics/webimage/imagedata">Manipulating ImageData</a>
             </li>
             <li>
+                <a href="graphics/webimage/setimage">setImage</a>
+            </li>
+            <li>
                 <a href="graphics/webimage/rotation">Rotation</a>
             </li>
             <li>

--- a/src/graphics/webimage.js
+++ b/src/graphics/webimage.js
@@ -73,8 +73,14 @@ class WebImage extends Thing {
         this._hiddenCanvas.width = 1;
         this._hiddenCanvas.height = 1;
 
+        if (this.image) {
+            // if this WebImage had an existing image, it may have an unresolved onload callback.
+            // dont allow original callback to resolve, since it might attempt to load pixel data
+            // from a potentially empty canvas.
+            this.image.onload = null;
+        }
         this.image = new Image();
-        this.image.crossOrigin = true;
+        this.image.crossOrigin = 'anonymous';
         this.image.src = filename;
         this.filename = filename;
         this.width = null;

--- a/src/graphics/webimage.js
+++ b/src/graphics/webimage.js
@@ -72,7 +72,6 @@ class WebImage extends Thing {
         this._hiddenCanvas = document.createElement('canvas');
         this._hiddenCanvas.width = 1;
         this._hiddenCanvas.height = 1;
-
         if (this.image) {
             // if this WebImage had an existing image, it may have an unresolved onload callback.
             // dont allow original callback to resolve, since it might attempt to load pixel data

--- a/test/webimage.test.js
+++ b/test/webimage.test.js
@@ -182,6 +182,32 @@ describe('WebImage', () => {
             expect(topLeftPixel).toEqual([0, 0, 255, 255]);
         });
     });
+    describe('setImage', () => {
+        it('Allows replacing the image of the WebImage', () => {
+            const g = new Graphics({ shouldUpdate: false });
+            const img = new WebImage('www.codehs.com/doesnt-matter.gif');
+            img.setImage(RGBURL);
+            g.add(img);
+            img.loaded(() => {
+                g.redraw();
+                expect(g.getPixel(0, 0)).toEqual([255, 0, 0, 255]);
+            });
+        });
+        it('Cancels the original onload of the image', () => {
+            const g = new Graphics({ shouldUpdate: false });
+            const img = new WebImage('www.codehs.com/doesnt-matter.gif');
+            const firstLoadedSpy = jasmine.createSpy();
+            // we have to inspect here to get the actual onload event
+            img.image.onload = firstLoadedSpy;
+            img.setImage(RGBURL);
+            g.add(img);
+            img.loaded(() => {
+                g.redraw();
+                expect(g.getPixel(0, 0)).toEqual([255, 0, 0, 255]);
+                expect(firstLoadedSpy).not.toHaveBeenCalled();
+            });
+        });
+    });
     describe('setRed/Blue/Green/Alpha', () => {
         it('Updates the underlying data', () => {
             const img = new WebImage(RGBURL);


### PR DESCRIPTION
<!--

Thank you for contributing! Please use this pull request (PR) template.
In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing.
If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".

-->
Resolves #130 

## Summary
<!--
Include a summary of your changes. What problem are you addressing, and how does this solution addres it?
-->
This fixes a bug that could arise when a WebImage had an outstanding `onload` callback that hadn't yet resolved and `setImage` was called again. The existing `onload` could resolve at a time when there was invalid image data. This resolves that by removing any existing onload handlers.

## Changes:
<!--
Include what specific changes were made in this pull request.
-->
- Explicitly remove any existing onload callbacks when setting the image with `setImage`
- Tests


## Screenshots of the change:
<!--
If applicable, add screenshots depicting the changes.
-->

## Checklist
<!--
To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab!
Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm test` passes
- [x] Unit tests are included / updated
- [x] Documentation has been updated where relevant

<!-- Pull Request Template from p5.js https://github.com/processing/p5.js/blob/main/.github/PULL_REQUEST_TEMPLATE.md -->
