### PR TITLE
Disallow sub 1 device pixel ratio

### DIFF
--- a/src/graphics/group.js
+++ b/src/graphics/group.js
@@ -23,7 +23,7 @@ class Group extends Thing {
      * @private
      * @type {number}
      */
-    devicePixelRatio = window.devicePixelRatio ?? 1;
+    devicePixelRatio = Math.ceil(window.devicePixelRatio) ?? 1;
 
     /**
      * Constructs a new Group.

--- a/src/graphics/index.js
+++ b/src/graphics/index.js
@@ -34,7 +34,7 @@ class GraphicsManager extends Manager {
      * @private
      * @type {number}
      */
-    devicePixelRatio = window.devicePixelRatio ?? 1;
+    devicePixelRatio = Math.ceil(window.devicePixelRatio) ?? 1;
 
     /**
      * Set up an instance of the graphics library.

--- a/test/graphics.test.js
+++ b/test/graphics.test.js
@@ -20,6 +20,14 @@ describe('Graphics', () => {
             expect(canvas.width).toEqual(20 * window.devicePixelRatio);
             expect(canvas.height).toEqual(20 * window.devicePixelRatio);
         });
+        it('Rounds devicePixelRatio to prevent floating point sizes', () => {
+            window.devicePixelRatio = 0.89999;
+            const g = new Graphics({ shouldUpdate: false });
+            g.setSize(20, 20);
+            const canvas = document.querySelector('canvas');
+            expect(canvas.width).toEqual(20);
+            expect(canvas.height).toEqual(20);
+        });
     });
     describe('setFullscreen', () => {
         it("Updates the canvas' size to the parent's size less padding less border", () => {

--- a/test/setup.js
+++ b/test/setup.js
@@ -14,6 +14,7 @@ beforeEach(() => {
 
 afterEach(() => {
     document.body.innerHTML = '';
+    window.devicePixelRatio = 1;
     Object.entries(GraphicsInstances).forEach(([id, instance]) => {
         instance.cleanup();
     });


### PR DESCRIPTION
<!--

Thank you for contributing! Please use this pull request (PR) template.
In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing.
If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".

-->

## Summary
<!--
Include a summary of your changes. What problem are you addressing, and how does this solution addres it?
-->
There was a bug where a sub-1 devicePixelRatio would cause floating point values for getWidth(), getHeight(), etc.
This makes sure that devicePixelRatio can never be lower than 1 to prevent these issues.

## Changes:
<!--
Include what specific changes were made in this pull request.
-->
- Groups and main Graphics instance don't allow sub-zero devicePixelRatios
- Tests


## Checklist
<!--
To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab!
Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm test` passes
- [x] Unit tests are included / updated
- [x] Documentation has been updated where relevant

<!-- Pull Request Template from p5.js https://github.com/processing/p5.js/blob/main/.github/PULL_REQUEST_TEMPLATE.md -->
