### PR TITLE
Allow console to be configured with a prompt function

### DIFF
--- a/src/console/index.js
+++ b/src/console/index.js
@@ -45,11 +45,17 @@ class Console {
      * or `println` or internal calls within the library. If onPrint is undefined, console.log
      * is used as a fallback.
      * @param {function} options.clear Function invoked when clear() is called.
+     * @param {function} options.prompt Function that transforms the prompt string to a function like `readInt` before it is passed to `prompt`.
      */
     constructor(options = {}) {
         this.onInput = options.input ?? (async promptString => await prompt(promptString));
         this.onOutput = options.output ?? window.console.log.bind(window.console);
         this.onClear = options.clear ?? window.console.clear.bind(window.console);
+        this.promptTransform =
+            options.prompt ??
+            ((promptString, defaultValue) => {
+                return promptString;
+            });
     }
 
     /**
@@ -67,11 +73,13 @@ class Console {
      * or `println` or internal calls within the library. If onPrint is undefined, console.log
      * is used as a fallback.
      * @param {function} options.clear Function invoked when clear() is called.
+     * @param {function} options.prompt Function that transforms the prompt string to a function like `readInt` before it is passed to `prompt`.
      */
     configure(options = {}) {
         this.onInput = options.input ?? this.onInput;
         this.onOutput = options.output ?? this.onOutput;
         this.onClear = options.clear ?? this.onClear;
+        this.promptTransform = options.prompt ?? this.promptTransform;
     }
 
     /**
@@ -79,7 +87,7 @@ class Console {
      * @param {string} promptString - The line to be printed before prompting.
      */
     readLinePrivate(promptString) {
-        const input = prompt(promptString);
+        const input = prompt(this.promptTransform(promptString));
         return input;
     }
 

--- a/test/console.test.js
+++ b/test/console.test.js
@@ -125,6 +125,14 @@ describe('Console', () => {
                 const c = new Console();
                 expect(c.readLine('Next line?')).toBeNull();
             });
+            it('Will invoke a configured prompt first', () => {
+                const promptSpy = jasmine.createSpy().and.returnValue('modified prompt');
+                const windowPromptSpy = spyOn(window, 'prompt').and.returnValue(null);
+                const c = new Console({ prompt: promptSpy });
+                c.readLine('give me a line!');
+                expect(promptSpy).toHaveBeenCalledOnceWith('give me a line!');
+                expect(windowPromptSpy).toHaveBeenCalledOnceWith('modified prompt');
+            });
         });
         describe('readFloat', () => {
             it('Errors for >1 argument', () => {
@@ -145,6 +153,14 @@ describe('Console', () => {
                     ["'two' was not a float. Please try again.\nGive me a float: "],
                 ]);
                 expect(int).toBe(3.0);
+            });
+            it('Will invoke a configured prompt first', () => {
+                const promptSpy = jasmine.createSpy().and.returnValue('modified prompt');
+                const windowPromptSpy = spyOn(window, 'prompt').and.returnValue(null);
+                const c = new Console({ prompt: promptSpy });
+                c.readFloat('give me a float!');
+                expect(promptSpy).toHaveBeenCalledOnceWith('give me a float!');
+                expect(windowPromptSpy).toHaveBeenCalledOnceWith('modified prompt');
             });
         });
         describe('readInt', () => {
@@ -187,6 +203,14 @@ describe('Console', () => {
                 expect(promptSpy).toHaveBeenCalledTimes(100);
                 expect(int).toBe(0);
             });
+            it('Will invoke a configured prompt first', () => {
+                const promptSpy = jasmine.createSpy().and.returnValue('modified prompt');
+                const windowPromptSpy = spyOn(window, 'prompt').and.returnValue(null);
+                const c = new Console({ prompt: promptSpy });
+                c.readInt('give me an int!');
+                expect(promptSpy).toHaveBeenCalledOnceWith('give me an int!');
+                expect(windowPromptSpy).toHaveBeenCalledOnceWith('modified prompt');
+            });
         });
         describe('readBoolean', () => {
             it('Errors for >1 argument', () => {
@@ -224,6 +248,14 @@ describe('Console', () => {
                     ["'yep' was not a boolean (true/false). Please try again.\nGive me a bool: "],
                 ]);
                 expect(bool).toBeTrue();
+            });
+            it('Will invoke a configured prompt first', () => {
+                const promptSpy = jasmine.createSpy().and.returnValue('modified prompt');
+                const windowPromptSpy = spyOn(window, 'prompt').and.returnValue(null);
+                const c = new Console({ prompt: promptSpy });
+                c.readInt('give me a boolean!');
+                expect(promptSpy).toHaveBeenCalledOnceWith('give me a boolean!');
+                expect(windowPromptSpy).toHaveBeenCalledOnceWith('modified prompt');
             });
         });
     });


### PR DESCRIPTION
…s the text passed to the window.prompt function

<!--

Thank you for contributing! Please use this pull request (PR) template.
In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing.
If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".

-->
## Summary
<!--
Include a summary of your changes. What problem are you addressing, and how does this solution addres it?
-->
CodeHS, and other places which might use this library, will need the text passed into `window.prompt` to contain the previous lines printed so that the user can see them before responding. This is necessary because blocking input prevents those lines from being written anywhere before the prompt.
This was configured with `onInput` before #137 , and this restores that with the `prompt` function which becomes `promptTransform` in the console instance.

## Changes:
<!--
Include what specific changes were made in this pull request.
-->
- Expose `prompt` configuration for `Console` that allows for the message to `prompt` to be transformed before it's passed into `window.prompt`.


## Checklist
<!--
To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab!
Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm test` passes
- [x] Unit tests are included / updated
- [x] Documentation has been updated where relevant

<!-- Pull Request Template from p5.js https://github.com/processing/p5.js/blob/main/.github/PULL_REQUEST_TEMPLATE.md -->
