### PR TITLE
Print succesfully parsed results from readNumber family of functions

### DIFF
--- a/src/console/index.js
+++ b/src/console/index.js
@@ -160,7 +160,7 @@ class Console {
      * @private
      */
     readNumber(str, parseFn, errorMsgType, asynchronous) {
-        const DEFAULT = 0; // If we get into an infinite recursion, return DEFAULT.
+        const DEFAULT = Symbol(); // If we get into an infinite recursion, return DEFAULT.
         const MAX_RECURSION_DEPTH = 100;
         // a special indicator that th program should be exiting
         const ABORT = Symbol('ABORT');
@@ -215,7 +215,17 @@ class Console {
                 }
             }
         };
-        return attemptInput(promptString, 0, asynchronous);
+        const result = attemptInput(promptString, 0, asynchronous);
+        if (result === DEFAULT) {
+            return 0;
+        }
+        if (result === null) {
+            return null;
+        }
+        // success
+        this.print(str);
+        this.println(result);
+        return result;
     }
 
     /**

--- a/test/console.test.js
+++ b/test/console.test.js
@@ -133,6 +133,13 @@ describe('Console', () => {
                 expect(promptSpy).toHaveBeenCalledOnceWith('give me a line!');
                 expect(windowPromptSpy).toHaveBeenCalledOnceWith('modified prompt');
             });
+            it('Prints a parsed result', () => {
+                const promptSpy = spyOn(window, 'prompt').and.returnValue('hiya');
+                const outputSpy = jasmine.createSpy();
+                const c = new Console({ output: outputSpy });
+                c.readLine('give me a line!');
+                expect(outputSpy.calls.allArgs()).toEqual([['give me a line!'], ['hiya', '\n']]);
+            });
         });
         describe('readFloat', () => {
             it('Errors for >1 argument', () => {
@@ -210,6 +217,20 @@ describe('Console', () => {
                 c.readInt('give me an int!');
                 expect(promptSpy).toHaveBeenCalledOnceWith('give me an int!');
                 expect(windowPromptSpy).toHaveBeenCalledOnceWith('modified prompt');
+            });
+            it('Prints a parsed result', () => {
+                const promptSpy = spyOn(window, 'prompt').and.returnValue(1);
+                const outputSpy = jasmine.createSpy();
+                const c = new Console({ output: outputSpy });
+                c.readInt('give me an int!');
+                expect(outputSpy.calls.allArgs()).toEqual([['give me an int!'], [1, '\n']]);
+            });
+            it('Doesnt print a default value', () => {
+                const promptSpy = spyOn(window, 'prompt').and.returnValue(null);
+                const outputSpy = jasmine.createSpy();
+                const c = new Console({ output: outputSpy });
+                c.readInt('give me an int!');
+                expect(outputSpy.calls.allArgs()).toEqual([]);
             });
         });
         describe('readBoolean', () => {


### PR DESCRIPTION


## Summary
<!--
Include a summary of your changes. What problem are you addressing, and how does this solution addres it?
-->
When `readNumber`, `readFloat` or `readBoolean` successfully parse a value, print the prompt and result.

## Changes:
<!--
Include what specific changes were made in this pull request.
-->
- Handle unparsed results in `readNumber` differently, so that a failed input doesn't print
- Tests

## Checklist
<!--
To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab!
Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm test` passes
- [x] Unit tests are included / updated
- [x] Documentation has been updated where relevant

<!-- Pull Request Template from p5.js https://github.com/processing/p5.js/blob/main/.github/PULL_REQUEST_TEMPLATE.md -->
