### PR TITLE
Decouple Groups' bounds from their position to fix anchoring issues

### DIFF
--- a/site/examples/graphics/polygon/negativecoordinates/negativecoordinates.js
+++ b/site/examples/graphics/polygon/negativecoordinates/negativecoordinates.js
@@ -1,0 +1,15 @@
+let darkMode = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+
+let color = 'blue';
+if (darkMode) {
+    color = 'yellow';
+}
+const t1 = new Polygon();
+t1.addPoint(-30, 0);
+t1.addPoint(30, 30);
+t1.addPoint(0, 30);
+t1.debug = true;
+t1.setPosition(getWidth() / 2, getHeight() / 2);
+t1.setAnchor({ horizontal: 0, vertical: 0 });
+t1.setColor(color);
+add(t1);

--- a/site/examples/graphics/polygon/negativecoordinates/negativecoordinates.md
+++ b/site/examples/graphics/polygon/negativecoordinates/negativecoordinates.md
@@ -1,0 +1,7 @@
+---
+title: Polygon - Negative Coordiantes
+layout: example
+code: negativecoordinates.js
+---
+
+Polygons can contain points which are negative relative to their position. This affects bounding box calculations.

--- a/site/examples/groups/anchor/anchor.js
+++ b/site/examples/groups/anchor/anchor.js
@@ -42,3 +42,7 @@ g3.setPosition((3 * getWidth()) / 4, getHeight() / 2);
 g3.setAnchor({ vertical: 1, horizontal: 1 });
 g3.debug = true;
 add(g3);
+
+console.log(g1.getBounds());
+console.log(g2.getBounds());
+console.log(g3.getBounds());

--- a/src/graphics/group.js
+++ b/src/graphics/group.js
@@ -44,10 +44,21 @@ class Group extends Thing {
         this._hiddenCanvas = document.createElement('canvas');
         this._hiddenCanvas.width = 1;
         this._hiddenCanvas.height = 1;
-        document.body.appendChild(this._hiddenCanvas);
         this._hiddenContext = this._hiddenCanvas.getContext('2d');
         this._lastRecordedBounds = {};
         this.bounds = null;
+        /**
+         * The left-most x coordinate of elements in this group, which is considered its x value.
+         * @private
+         * @type {number}
+         */
+        this._minX = 0;
+        /**
+         * The top-most y coordinate of elements in this group, which is considered its y value.
+         * @private
+         * @type {number}
+         */
+        this._minY = 0;
     }
 
     /**
@@ -55,15 +66,17 @@ class Group extends Thing {
      * @type {number}
      */
     get x() {
-        const bounds = this.getBounds();
-        return bounds.left + (bounds.right - bounds.left) * this.anchor.horizontal;
+        if (this._boundsInvalidated) {
+            this._updateBounds();
+        }
+        return this._minX;
     }
 
     set x(x) {
         if (!this.bounds) {
             return;
         }
-        this.setPosition(x, this.bounds.top);
+        this.setPosition(x, this._minY);
     }
 
     /**
@@ -71,15 +84,17 @@ class Group extends Thing {
      * @type {number}
      */
     get y() {
-        const bounds = this.getBounds();
-        return bounds.top + (bounds.bottom - bounds.top) * this.anchor.vertical;
+        if (this._boundsInvalidated) {
+            this._updateBounds();
+        }
+        return this._minY;
     }
 
     set y(y) {
         if (!this.bounds) {
             return;
         }
-        this.setPosition(this.bounds.left, y);
+        this.setPosition(this._minX, y);
     }
 
     /**
@@ -160,9 +175,8 @@ class Group extends Thing {
      * @param {number} y
      */
     setPosition(x, y) {
-        const bounds = this.getBounds();
-        const dx = x - bounds.left;
-        const dy = y - bounds.top;
+        const dx = x - this.x;
+        const dy = y - this.y;
         this.move(dx, dy);
     }
 
@@ -282,6 +296,8 @@ class Group extends Thing {
             top: minY - this.anchor.vertical * height,
             bottom: maxY - this.anchor.vertical * height,
         };
+        this._minX = minX;
+        this._minY = minY;
         this._hiddenCanvas.width = this.devicePixelRatio * width;
         this._hiddenCanvas.height = this.devicePixelRatio * height;
         this._hiddenCanvas.style.width = `${width}px`;

--- a/src/graphics/group.js
+++ b/src/graphics/group.js
@@ -44,6 +44,7 @@ class Group extends Thing {
         this._hiddenCanvas = document.createElement('canvas');
         this._hiddenCanvas.width = 1;
         this._hiddenCanvas.height = 1;
+        document.body.appendChild(this._hiddenCanvas);
         this._hiddenContext = this._hiddenCanvas.getContext('2d');
         this._lastRecordedBounds = {};
         this.bounds = null;
@@ -54,7 +55,8 @@ class Group extends Thing {
      * @type {number}
      */
     get x() {
-        return this.getBounds().left;
+        const bounds = this.getBounds();
+        return bounds.left + (bounds.right - bounds.left) * this.anchor.horizontal;
     }
 
     set x(x) {
@@ -69,7 +71,8 @@ class Group extends Thing {
      * @type {number}
      */
     get y() {
-        return this.getBounds().top;
+        const bounds = this.getBounds();
+        return bounds.top + (bounds.bottom - bounds.top) * this.anchor.vertical;
     }
 
     set y(y) {
@@ -184,14 +187,14 @@ class Group extends Thing {
             // in the top left corner.
             // this means that only the bounding box surrounding the top
             // left corner needs to be drawn to the destination canvas
-            this._hiddenContext.translate(-bounds.left, -bounds.top);
+            this._hiddenContext.translate(-this.x, -this.y);
             this.elements
                 .filter(element => element.alive)
                 .sort((a, b) => a.layer - b.layer)
                 .forEach(element => {
                     element.draw(this._hiddenContext);
                 });
-            this._hiddenContext.translate(bounds.left, bounds.top);
+            this._hiddenContext.translate(this.x, this.y);
             context.drawImage(this._hiddenCanvas, 0, 0, width, height);
             context.closePath();
         });
@@ -271,14 +274,14 @@ class Group extends Thing {
             maxX = Math.max(maxX, right);
             maxY = Math.max(maxY, bottom);
         });
-        this.bounds = {
-            left: minX,
-            right: maxX,
-            top: minY,
-            bottom: maxY,
-        };
         const width = maxX - minX;
         const height = maxY - minY;
+        this.bounds = {
+            left: minX - this.anchor.horizontal * width,
+            right: maxX - this.anchor.horizontal * width,
+            top: minY - this.anchor.vertical * height,
+            bottom: maxY - this.anchor.vertical * height,
+        };
         this._hiddenCanvas.width = this.devicePixelRatio * width;
         this._hiddenCanvas.height = this.devicePixelRatio * height;
         this._hiddenCanvas.style.width = `${width}px`;

--- a/src/graphics/thing.js
+++ b/src/graphics/thing.js
@@ -571,6 +571,7 @@ class Thing {
             context.strokeStyle = 'red';
             context.fill();
             const bounds = this.getBounds();
+            // move back to the origin
             context.translate(-drawX, -drawY);
             context.strokeRect(
                 bounds.left,

--- a/test/group.test.js
+++ b/test/group.test.js
@@ -149,15 +149,33 @@ describe('Groups', () => {
                 right: 5,
             });
         });
+        it('Considers anchoring', () => {
+            const g = new Group();
+            g.add(new Rectangle(10, 10));
+            expect(g.getBounds().left).toEqual(0);
+            g.setAnchor({ horizontal: 1.0, vertical: 0 });
+            expect(g.getBounds().left).toEqual(-10);
+            g.setAnchor({ horizontal: 0.5, vertical: 0.5 });
+            expect(g.getBounds()).toEqual({ top: -5, left: -5, right: 5, bottom: 5 });
+        });
     });
     describe('Positioning', () => {
-        it('A groups x is its left bound', () => {
+        it("A Group's x is its left bound", () => {
             const g = new Group();
             g.add(new Rectangle(20, 20));
             expect(g.x).toEqual(g.getBounds().left);
             g.setPosition(10, 10);
             expect(g._boundsInvalidated).toBeTrue();
             expect(g.x).toEqual(g.getBounds().left);
+            expect(g.x).toEqual(10);
+        });
+        it("A Group's anchoring doesn't affect its position", () => {
+            const g = new Group();
+            g.add(new Rectangle(20, 20));
+            expect(g.x).toEqual(0);
+            g.setPosition(10, 10);
+            expect(g.x).toEqual(10);
+            g.setAnchor({ horizontal: 1.0, vertical: 0 });
             expect(g.x).toEqual(10);
         });
     });

--- a/test/polygon.test.js
+++ b/test/polygon.test.js
@@ -7,6 +7,15 @@ describe('Polygon', () => {
             expect(new Polygon().type).toEqual('Polygon');
         });
     });
+    describe("A Polygon's position (x, y)", () => {
+        it('Is unaffected by adding points', () => {
+            const p = new Polygon();
+            p.addPoint(10, 10);
+            p.addPoint(20, 10);
+            p.addPoint(10, 20);
+            expect(p.x).toEqual(0);
+        });
+    });
     describe('addPoint', () => {
         it("Invalidates the superclass's bounds", () => {
             const p = new Polygon();
@@ -27,6 +36,7 @@ describe('Polygon', () => {
             p.addPoint(30, 0);
             p.addPoint(200, 0);
             expect(p.getWidth()).toBe(200);
+            expect(p.width).toBe(200);
         });
     });
     describe('getHeight()', () => {
@@ -37,6 +47,7 @@ describe('Polygon', () => {
             p.addPoint(0, 120);
             p.addPoint(0, 90);
             expect(p.getHeight()).toBe(100);
+            expect(p.height).toBe(100);
         });
     });
     describe('move()', () => {
@@ -107,6 +118,26 @@ describe('Polygon', () => {
                 left: -60,
                 bottom: 15,
                 right: 0,
+            });
+        });
+        it('Its bounds are affected by anchoring', () => {
+            const p = new Polygon();
+            p.addPoint(-10, 0);
+            p.addPoint(10, 0);
+            p.addPoint(10, 20);
+            p.addPoint(-10, 20);
+            expect(p.getBounds()).toEqual({
+                top: 0,
+                left: -10,
+                right: 10,
+                bottom: 20,
+            });
+            p.setAnchor({ vertical: 1, horizontal: 1 });
+            expect(p.getBounds()).toEqual({
+                top: -20,
+                left: -30,
+                bottom: 0,
+                right: -10,
             });
         });
     });


### PR DESCRIPTION
Fixes #141 

## Summary
<!--
Include a summary of your changes. What problem are you addressing, and how does this solution addres it?
-->
#141 describes the bug, but Groups' bounds were tied to their position, which meant that the bounding box displayed incorrectly.

## Changes:
<!--
Include what specific changes were made in this pull request.
-->
- Introduce internal `_minX` and `_minY` to a Group, which stores its top left corner, which is used to position it

## Screenshots of the change:
<!--
If applicable, add screenshots depicting the changes.
-->
<img width="325" alt="image" src="https://user-images.githubusercontent.com/6645121/163072459-bd02762e-2d0b-4c11-9c20-022a3f01b275.png">


## Checklist
<!--
To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab!
Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm test` passes
- [x] Unit tests are included / updated
- [x] Documentation has been updated where relevant

<!-- Pull Request Template from p5.js https://github.com/processing/p5.js/blob/main/.github/PULL_REQUEST_TEMPLATE.md -->
