### PR TITLE
Fixes for WebImage downsizing and add imageSmoothing

### DIFF
--- a/site/examples/graphics/webimage/imagesmoothing/imagesmoothing.js
+++ b/site/examples/graphics/webimage/imagesmoothing/imagesmoothing.js
@@ -1,0 +1,20 @@
+const smoothed = new WebImage('https://codehs.com/uploads/72e9b6f60ac412f32a2fd3a955990c3b');
+smoothed.imageSmoothingEnabled = true;
+const unsmoothed = new WebImage('https://codehs.com/uploads/72e9b6f60ac412f32a2fd3a955990c3b');
+unsmoothed.imageSmoothingEnabled = false;
+
+add(smoothed);
+add(unsmoothed);
+
+unsmoothed.setPosition(getWidth() / 2, 0);
+
+const smoothedLoaded = new Promise(resolve => smoothed.loaded(resolve));
+const unsmoothedLoaded = new Promise(resolve => unsmoothed.loaded(resolve));
+
+const allLoaded = Promise.all([smoothedLoaded, unsmoothedLoaded]).then(() => {
+    const imageWidth = smoothed.width;
+    const scale = getWidth() / 2 / imageWidth;
+    smoothed.setSize(scale * smoothed.width, scale * smoothed.height);
+    unsmoothed.setSize(scale * unsmoothed.width, scale * unsmoothed.height);
+    setSize(smoothed.width * 2, smoothed.height);
+});

--- a/site/examples/graphics/webimage/imagesmoothing/imagesmoothing.md
+++ b/site/examples/graphics/webimage/imagesmoothing/imagesmoothing.md
@@ -1,0 +1,13 @@
+---
+title: WebImage - imageSmoothing
+layout: example
+code: imagesmoothing.js
+width: 500
+height: 500
+---
+
+`imageSmoothingEnabled` controls how an image is drawn when scaled up.
+
+If `imageSmoothingEnabled` is true, pixels will be blurred.
+
+If `imageSmoothingEnabled` is false, clear edges of pixels will be preserved.

--- a/site/examples/index.html
+++ b/site/examples/index.html
@@ -173,6 +173,9 @@ layout: base
                 <a href="graphics/webimage/flashlight">Flashlight</a>
             </li>
             <li>
+                <a href="graphics/webimage/imagesmoothing">Image Smoothing</a>
+            </li>
+            <li>
                 <a href="graphics/webimage/imagedata">Manipulating ImageData</a>
             </li>
             <li>

--- a/src/graphics/webimage.js
+++ b/src/graphics/webimage.js
@@ -44,6 +44,13 @@ class WebImage extends Thing {
          * @type {boolean}
          */
         this.imageLoaded = false;
+        /**
+         * Whether image smoothing should be applied when the image is scaled up.
+         * For more information, see {@link https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/imageSmoothingEnabled}
+         * @default false
+         * @type {boolean}
+         */
+        this.imageSmoothingEnabled = false;
     }
 
     /**
@@ -119,19 +126,12 @@ class WebImage extends Thing {
             this.updateHiddenCanvas();
         }
         super.draw(context, () => {
+            const existingImageSmoothing = context.imageSmoothingEnabled;
             context.beginPath();
-            // the __hiddenCanvas contains the ImageData, sized as it originally was.
-            // in order to perform scaling, the destination width and height are
-            // currentWidth * (currentWidth / originalWidth),
-            // meaning the current size times the amount the size has changed
-            context.drawImage(
-                this._hiddenCanvas,
-                0,
-                0,
-                (this.width * this.width) / this.data.width,
-                (this.height * this.height) / this.data.height
-            );
+            context.imageSmoothingEnabled = this.imageSmoothingEnabled;
+            context.drawImage(this._hiddenCanvas, 0, 0, this.width, this.height);
             context.closePath();
+            context.imageSmoothingEnabled = existingImageSmoothing;
         });
     }
 
@@ -370,8 +370,6 @@ class WebImage extends Thing {
      * This is automatically called after operations that modify ImageData.
      */
     updateHiddenCanvas() {
-        this._hiddenCanvas.width = Math.max(this._hiddenCanvas.width, this.width);
-        this._hiddenCanvas.height = Math.max(this._hiddenCanvas.height, this.height);
         const context = this._hiddenCanvas.getContext('2d');
         context.putImageData(this.data, 0, 0);
         this._hiddenCanvasOutOfSync = false;

--- a/test/webimage.test.js
+++ b/test/webimage.test.js
@@ -246,4 +246,24 @@ describe('WebImage', () => {
             });
         });
     });
+    describe('Resizing', () => {
+        it('Properly shrinks the WebImage', () => {
+            const img = new WebImage(RGBURL);
+            const g = new Graphics({ shouldUpdate: false });
+            g.add(img);
+            return new Promise(resolve => {
+                img.loaded(() => {
+                    g.redraw();
+                    // the img is 90x90
+                    let bottomRightPixel = g.getPixel(89, 89);
+                    expect(bottomRightPixel).toEqual([0, 0, 255, 255]);
+                    img.setSize(50, 50);
+                    g.redraw();
+                    bottomRightPixel = g.getPixel(49, 49);
+                    expect(bottomRightPixel).toEqual([0, 0, 255, 255]);
+                    resolve();
+                });
+            });
+        });
+    });
 });


### PR DESCRIPTION
<!--

Thank you for contributing! Please use this pull request (PR) template.
In the description field of this PR, include "resolves #XXXX" tagging the issue you are fixing.
If this PR addresses the issue but doesn't completely resolve it (ie the issue should remain open after your PR is merged), write "addresses #XXXX".

-->
Resolves #143 

## Summary
<!--
Include a summary of your changes. What problem are you addressing, and how does this solution addres it?
-->
There was an issue with downsizing a `WebImage` where the hidden canvas used for drawing the image was being resized. No idea why I was doing that in the first place, probably just trying to be clever.

## Changes:
<!--
Include what specific changes were made in this pull request.
-->
- Fix WebImage downscaling
- Add `imageSmoothingEnabled` boolean to `WebImage`
- `imageSmoothingEnabled` example


## Checklist
<!--
To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab!
Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm test` passes
- [x] Unit tests are included / updated
- [x] Documentation has been updated where relevant

<!-- Pull Request Template from p5.js https://github.com/processing/p5.js/blob/main/.github/PULL_REQUEST_TEMPLATE.md -->
