### PR TITLE
call resetDimensions on Text when we update the label

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
     "name": "chs-js-lib",
-    "version": "0.3.4",
+    "version": "0.3.5",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "version": "0.3.4",
+            "version": "0.3.5",
             "license": "ISC",
             "dependencies": {
                 "http-server": "^14.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "chs-js-lib",
-    "version": "0.3.4",
+    "version": "0.3.5",
     "description": "JavaScript graphics library used in CodeHS's platform.",
     "main": "dist/chs.cjs",
     "module": "dist/chs.mjs",

--- a/src/graphics/text.js
+++ b/src/graphics/text.js
@@ -122,6 +122,7 @@ class Text extends Thing {
             );
         }
         this.label = label;
+        this.resetDimensions()
     }
 
     /**
@@ -143,6 +144,7 @@ class Text extends Thing {
             );
         }
         this.label = label;
+        this.resetDimensions()
     }
 
     /**

--- a/test/text.test.js
+++ b/test/text.test.js
@@ -87,6 +87,12 @@ describe('Text', () => {
             t.setText('fdsa');
             expect(t.label).toEqual('fdsa');
         });
+        it('Updates dimensions', () => {
+            const t = new Text('mmmm');
+            const originalWidth = t.getWidth();
+            t.setText('mmmmmmm');
+            expect(t.getWidth()).toBeGreaterThan(originalWidth);
+        });
     });
     describe('setLabel', () => {
         it('Errors for invalid arguments', () => {
@@ -108,6 +114,12 @@ describe('Text', () => {
             const t = new Text('asdf');
             t.setLabel('fdsa');
             expect(t.label).toEqual('fdsa');
+        });
+        it('Updates dimensions', () => {
+            const t = new Text('mmmm');
+            const originalWidth = t.getWidth();
+            t.setLabel('mmmmmmm');
+            expect(t.getWidth()).toBeGreaterThan(originalWidth);
         });
     });
     describe('containsPoint', () => {


### PR DESCRIPTION
call resetDimensions on Text when we update the label with `setText` or `setLabel`. 

fixes #145 

## Summary
Fixes a bug that doesn't reset the dimensions of a `Text` object when we change the label.

## Checklist
<!--
To check any option, replace the "[ ]" with a "[x]". Be sure to check out how it looks in the Preview tab!
Feel free to remove any portion of the template that is not relevant for your issue.
-->

- [x] `npm test` passes
- [x] Unit tests are included / updated
- [ ] Documentation has been updated where relevant (n/a - it's behind the scenes)

Once this goes live and is imported into the CodeHS repo, we can test at https://codehs.com/sandbox/id/texttester-NWPhxW

(replaces https://github.com/codehs/chs-js-lib/pull/146)