### PR TITLE
(Documentation) fixed anchor docs

### DIFF
--- a/src/graphics/thing.js
+++ b/src/graphics/thing.js
@@ -648,7 +648,7 @@ class Thing {
      * // this method is on every Shape
      * let thing = new Thing();
      * // center the object around its position
-     * thing.setPosition({vertical: 0.5, horizontal: 0.5});
+     * thing.setAnchor({vertical: 0.5, horizontal: 0.5});
      *
      * @param {{vertical: number, horizontal: number}} anchor
      */


### PR DESCRIPTION
@john-kelly 

Resolves ENG-4875

## Summary
Fixed an incorrect method name in the JSDoc code example for `setAnchor` on `Thing` — the example was calling `thing.setPosition(...)` instead of the correct `thing.setAnchor(...)`.

- [ ] `npm test` passes
- [ ] Unit tests are included / updated
- [ ] Documentation has been updated where relevant